### PR TITLE
Updated romcal to use correct lodash method for finding uniques with …

### DIFF
--- a/lib/seasons.js
+++ b/lib/seasons.js
@@ -262,7 +262,7 @@ var _christmastide = function() {
 
   // Override in order: solemnities, feasts, epiphany and octave of christmas
   // to days of christmas
-  d = _.uniq( _.union( epiphany, o, d ), function( item ) {
+  d = _.uniqBy( _.union( epiphany, o, d ), function( item ) {
     return item.moment.valueOf();
   });
 
@@ -571,7 +571,7 @@ var _lent = function() {
   var holyWeek = _holyWeek.apply( this, arguments );
 
   // Override in order: Solemnities, Holy Week and Sundays of Lent to days of Lent
-  days = _.uniq( _.union( holyWeek, sundays, days ), function( v ) {
+  days = _.uniqBy( _.union( holyWeek, sundays, days ), function( v ) {
     return v.moment.valueOf();
   });
 
@@ -709,7 +709,7 @@ var _eastertide = function() {
   });
 
   // Insert Solemnities and Sundays of Lent to days of Easter
-  days = _.uniq( _.union( sundays, days ), function( v ) {
+  days = _.uniqBy( _.union( sundays, days ), function( v ) {
     return v.moment.valueOf();
   });
 

--- a/test/02_seasons.js
+++ b/test/02_seasons.js
@@ -102,11 +102,11 @@ describe('Testing date range functions', function() {
     });
 
     it('The Saturday in the week after Ash Wednesday should be in the 1st week of Lent', function() {
-      Seasons.lent( 2017 ).filter(d => d.type === 'WEEKDAY')[10].key.toLowerCase().should.be.eql('saturdayofthe1stweekoflent');
+      Seasons.lent( 2017 ).filter(d => d.type === 'WEEKDAY')[9].key.toLowerCase().should.be.eql('saturdayofthe1stweekoflent');
     });
 
     it('The 2nd Sunday of Lent should be in the 2nd week of Lent', function() {
-      Seasons.lent( 2017 ).filter(d => d.type === 'WEEKDAY')[11].key.toLowerCase().should.be.eql('sundayofthe2ndweekoflent');
+      Seasons.lent( 2017 ).filter(d => d.type === 'SUNDAY')[1].key.toLowerCase().should.be.eql('2ndsundayoflent');
     });
   });
 


### PR DESCRIPTION
…a criterion.

lodash 3: _.uniq(array, [isSorted], [iteratee], [thisArg])
lodash 4: _.uniq(array)
lodash 4: _.uniqBy(array, [iteratee=_.identity])

Updated a test for lent season, because it accepted faulty data generated by wrong uniq(), like this weekday-sunday:
  { moment: moment.utc("2017-03-05T00:00:00.000+00:00"),
    type: 'WEEKDAY',
    name: 'Sunday of the 1st week of Lent',
    data: { season: [Object], meta: [Object], calendar: [Object] },
    key: 'sundayOfThe1stWeekOfLent',
    source: 'l' },

Travis CI build should be fine now.Updated romcal to use correct lodash method for finding
 uniques with a criterion.

lodash 3: _.uniq(array, [isSorted], [iteratee], [thisArg])
lodash 4: _.uniq(array)
lodash 4: _.uniqBy(array, [iteratee=_.identity])

Updated a test for lent season, because it accepted faulty data generated by wrong uniq, like this weekday-sunday:
  { moment: moment.utc("2017-03-05T00:00:00.000+00:00"),
    type: 'WEEKDAY',
    name: 'Sunday of the 1st week of Lent',
    data: { season: [Object], meta: [Object], calendar: [Object] },
    key: 'sundayOfThe1stWeekOfLent',
    source: 'l' },

Travis CI build should be fine now.