### PR TITLE
Add missing type:  & fix wrong specified types in brazil cal

### DIFF
--- a/calendars/brazil.js
+++ b/calendars/brazil.js
@@ -86,7 +86,7 @@ module.exports = {
           "meta": {
             "liturgicalColor": LiturgicalColors.RED,
             "titles": [
-              Titles.RED
+              Titles.MARTYR
             ]
           }
         }
@@ -119,7 +119,7 @@ module.exports = {
           "meta": {
             "liturgicalColor": LiturgicalColors.RED,
             "titles": [
-              Titles.RED
+              Titles.MARTYR
             ]
           }
         }

--- a/data/titles.json
+++ b/data/titles.json
@@ -3,5 +3,6 @@
   "FEAST_OF_THE_LORD": "Feast of the Lord",
   "DOCTOR_OF_THE_CHURCH": "Doctor of the Church",
   "MARIAN_FEAST": "Marian Feast",
+  "MARTYR": "Martyr",
   "TRIDUUM": "Triduum"
 }


### PR DESCRIPTION
The `MARTYR` title was already used in calendars, but wasn't defined in the `titles.json` (so this meta property was returning `null`).

Also fixed wrong titles in brazil calendar (probably wrong copy paste).