### PR TITLE
Rename weekday to feria

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ Each date in the liturgical calendar is assigned a type. romcal defines these ty
 6. `MEMORIAL`
 7. `OPT_MEMORIAL`
 8. `COMMEMORATION`
-9. `WEEKDAY`
+9. `FERIA`
 
-Where the importance or rank of the celebration is in descending order (Solemnity being of highest importance and weekday being the lowest).
+Where the importance or rank of the celebration is in descending order (Solemnity being of highest importance and feria being the lowest).
 
 Types play an important role in determining which celebration should take precendence over another when two or more celebrations coincide on the same date. Certain celebration types will also have different liturgical colors applied to them.
 

--- a/src/constants/Types.js
+++ b/src/constants/Types.js
@@ -7,6 +7,6 @@ const Types = [
   "MEMORIAL",           // [5]
   "OPT_MEMORIAL",       // [6]
   "COMMEMORATION",      // [7]
-  "WEEKDAY"             // [8]
+  "FERIA"               // [8]
 ];
 export default Types;

--- a/src/lib/Calendar.js
+++ b/src/lib/Calendar.js
@@ -299,7 +299,7 @@ const _applyDates = ( options, dates ) => {
         }
 
         //------------------------------------------------------------------
-        // MEMORIAL or OPT_MEMORIAL that fall on a WEEKDAY
+        // MEMORIAL or OPT_MEMORIAL that fall on a FERIA
         // in the SEASON OF LENT are reduced to a COMMEMORATION
         //------------------------------------------------------------------
         else if (
@@ -312,20 +312,20 @@ const _applyDates = ( options, dates ) => {
         }
 
         //------------------------------------------------------------------
-        // MEMORIAL or OPT_MEMORIAL that fall on a WEEKDAY
-        // outside LENT or the Easter Octave will replace the general WEEKDAY
+        // MEMORIAL or OPT_MEMORIAL that fall on a FERIA
+        // outside LENT or the Easter Octave will replace the general FERIA
         //------------------------------------------------------------------
         else if (
-          _.eq( date.type, _.last( Types ) ) // If the current date is of type weekday
-          && !_.eq( date.data.season.key, LiturgicalSeasons.LENT ) // And this weekday is not in Lent
+          _.eq( date.type, _.last( Types ) ) // If the current date is of type feria
+          && !_.eq( date.data.season.key, LiturgicalSeasons.LENT ) // And this feria is not in Lent
           && ( _.eq( candidate.type, Types[5] ) || _.eq( candidate.type, Types[6] ) ) // And the candidate is either a memorial or optional memorial
         ) {
-          replace = true; // Then the candidate is fit to replace the weekday
+          replace = true; // Then the candidate is fit to replace the feria
         }
 
         //------------------------------------------------------------------
-        // A non prioritized FEAST can only replace WEEKDAY \
-        // - weekday must not be in the octave of EASTER
+        // A non prioritized FEAST can only replace FERIA \
+        // - feria must not be in the octave of EASTER
         //------------------------------------------------------------------
         else if (
           _.eq( candidate.type, Types[4] )
@@ -350,9 +350,9 @@ const _applyDates = ( options, dates ) => {
         }
 
         //------------------------------------------------------------------
-        // A prioritized FEAST can replace a SUNDAY or WEEKDAY
+        // A prioritized FEAST can replace a SUNDAY or FERIA
         // When a Feast of the Lord falls on a SUNDAY it replaces the SUNDAY in Ordinary Time.
-        // - weekday must not be in the octave of EASTER
+        // - feria must not be in the octave of EASTER
         //------------------------------------------------------------------
         else if (
           _.eq( candidate.type, Types[4] )
@@ -374,7 +374,7 @@ const _applyDates = ( options, dates ) => {
         }
 
         //------------------------------------------------------------------
-        // A weekday can only replace a weekday
+        // A feria can only replace a feria
         // Sundays in Ordinary Time and Chrismastide take precedence over all other celebrations
         // except for SOLEMNITIES and certain FEASTS
         //------------------------------------------------------------------

--- a/src/lib/Dates.js
+++ b/src/lib/Dates.js
@@ -32,7 +32,7 @@ const epiphany = (y, epiphanyOnJan6 = false) => {
       case 0:
         date = firstDay.add( 7, 'days' );
         break;
-      // If first day of the year is on a weekday (i.e. Monday - Friday),
+      // If first day of the year is on a feria (i.e. Monday - Friday),
       // Epiphany will be celebrated on the Sunday proceeding
       default:
         date = firstDay.add( 1, 'weeks' ).startOf('week');
@@ -609,7 +609,7 @@ const holyFamily = y => {
   if ( _.eq( _christmas.day(), 0 ) ) {
     return moment.utc({ year: y, month: 11, day: 30 });
   }
-  // Holy Family is 1 week after Christmas when Christmas is on a Weekday
+  // Holy Family is 1 week after Christmas when Christmas is on a Feria
   else {
     return _christmas.add( 1, 'weeks' ).startOf('week');
   }

--- a/src/lib/Seasons.js
+++ b/src/lib/Seasons.js
@@ -1,14 +1,14 @@
 import moment from 'moment';
 import _ from 'lodash';
 
-import * as Dates from './Dates'; 
+import * as Dates from './Dates';
 import * as Utils from './Utils';
 
-import { 
-  LiturgicalSeasons, 
+import {
+  LiturgicalSeasons,
   PsalterWeeks,
-  LiturgicalColors, 
-  Types 
+  LiturgicalColors,
+  Types
 } from '../constants';
 
 //================================================================================================
@@ -97,7 +97,7 @@ const _holyWeek = y => {
       moment: date,
       type: Types[3],
       name: Utils.localize({
-        key: 'holyWeek.weekday',
+        key: 'holyWeek.feria',
         day: date.format('dddd')
       }),
       data: {
@@ -130,7 +130,7 @@ const advent = y => {
       moment: value,
       type: Utils.getTypeByDayOfWeek( value.day() ),
       name: Utils.localize({
-        key: ( _.eq( value.day(), 0 ) ? 'advent.sunday' : 'advent.weekday' ),
+        key: ( _.eq( value.day(), 0 ) ? 'advent.sunday' : 'advent.feria' ),
         day: value.format('dddd'),
         week: Math.floor( i / 7 ) + 1
       }),
@@ -263,7 +263,7 @@ const christmastide = (y, christmastideEnds, epiphanyOnJan6 = false, christmasti
   //==============================================================================
 
   // only merge the season of epiphany if the flag is true
-  if ( christmastideIncludesTheSeasonOfEpiphany === true ) { 
+  if ( christmastideIncludesTheSeasonOfEpiphany === true ) {
     d = _.uniqBy(_.union(epiphany, o, d), item => item.moment.valueOf());
   }
   else {
@@ -276,7 +276,7 @@ const christmastide = (y, christmastideEnds, epiphanyOnJan6 = false, christmasti
   //=====================================================================
   // PSALTER WEEKS & LITURGICAL COLORS - CHRISTMAS SEASON
   //---------------------------------------------------------------------
-  // If Christmas is on a weekday (Monday - Saturday), then the first
+  // If Christmas is on a feria (Monday - Saturday), then the first
   // week of Christmastide will follow the Psalter week of the 4th week
   // of Advent (which is always Psalter Week 4)
   // If Christmas is on a Sunday, the Psalter week will be Week 1
@@ -329,7 +329,7 @@ const earlyOrdinaryTime = (y, christmastideEnds, epiphanyOnJan6 = false) => {
       moment: value,
       type: ( _.eq( value.day(), 0 ) ? Types[1] : _.last( Types ) ),
       name: Utils.localize({
-        key: ( _.eq( value.day(), 0 ) ? 'ordinaryTime.sunday' : 'ordinaryTime.weekday' ),
+        key: ( _.eq( value.day(), 0 ) ? 'ordinaryTime.sunday' : 'ordinaryTime.feria' ),
         day: value.format('dddd'),
         week: ( _.eq( value.day(), 0 ) ?  Math.floor( i / 7 ) + 2 :  Math.floor( i / 7 ) + 1 )
       }),
@@ -366,7 +366,7 @@ const earlyOrdinaryTime = (y, christmastideEnds, epiphanyOnJan6 = false) => {
   // The proper color of ordinary time is green
   //=====================================================================
   let psalterWeek = 1;
-  
+
   _.map( days, v => {
 
     v.key = _.camelCase( v.name );
@@ -402,7 +402,7 @@ const laterOrdinaryTime = y => {
   // for later use
   let firstWeekOfLaterOrdinaryTime = 0;
   let days = [];
-  
+
   _.each( Dates.daysOfLaterOrdinaryTime(y).reverse(), ( value, i ) => {
 
     // Calculate the week of ordinary time
@@ -414,7 +414,7 @@ const laterOrdinaryTime = y => {
       moment: value,
       type: ( _.eq( value.day(), 0 ) ? Types[1] : _.last( Types ) ),
       name: Utils.localize({
-        key: ( _.eq( value.day(), 0 ) ? 'ordinaryTime.sunday' : 'ordinaryTime.weekday' ),
+        key: ( _.eq( value.day(), 0 ) ? 'ordinaryTime.sunday' : 'ordinaryTime.feria' ),
         day: value.format('dddd'),
         week: week
       }),
@@ -490,13 +490,13 @@ const lent = y => {
 
   let days = [];
   let sundays = [];
-  
+
   _.each( daysOfLent, (value, i) => {
     days.push({
       moment: value,
-      type: _.last( Types ), // Weekday
+      type: _.last( Types ), // Feria
       name: Utils.localize({
-        key: ( _.gt( i, 0 ) && _.lt( i, 4 ) ) ?  'lent.day_after_ash_wed' : 'lent.weekday',
+        key: ( _.gt( i, 0 ) && _.lt( i, 4 ) ) ?  'lent.day_after_ash_wed' : 'lent.feria',
         day: value.format('dddd'),
         week: Math.floor( (i - 4) / 7 ) + 1
       }),
@@ -510,7 +510,7 @@ const lent = y => {
       }
     });
   });
-  
+
   _.each( sundaysOfLent, ( value, i ) => {
     sundays.push({
       moment: value,
@@ -555,7 +555,7 @@ const lent = y => {
   // The proper color of the Lent is purple.
   //=====================================================================
   let psalterWeek = 4;
-  
+
   _.map( days, v => {
 
     v.key = _.camelCase( v.name );
@@ -613,13 +613,13 @@ const eastertide = y => {
   let d = Dates.daysOfEaster(y);
   let s = Dates.sundaysOfEaster(y);
   let days = [];
-  
+
   _.each( d, (value, i) => {
     days.push({
       moment: value,
       type: ( _.gt( i, 0 ) && _.lt( i, 7 ) ) ? _.head( Types ): _.last( Types ),
       name: Utils.localize({
-        key: ( _.gt( i, 0 ) && _.lt( i, 7 ) ) ?  'eastertide.octave' : 'eastertide.weekday',
+        key: ( _.gt( i, 0 ) && _.lt( i, 7 ) ) ?  'eastertide.octave' : 'eastertide.feria',
         day: value.format('dddd'),
         week: Math.floor( i / 7 ) + 1
       }),
@@ -636,7 +636,7 @@ const eastertide = y => {
   });
 
   let sundays = [];
-  
+
   _.each( s, ( value, i ) => {
     sundays.push({
       moment: value,
@@ -675,9 +675,9 @@ const eastertide = y => {
   //
   // The proper color of Easter is white
   //=====================================================================
-  
+
   let psalterWeek = 2;
-  
+
   _.map( days, ( v, k ) => {
 
     v.key = _.camelCase( v.name );

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -106,7 +106,7 @@ const localizeDates = (dates, source = 'national') => {
   });
 };
 
-// Types[1]: Sunday, _.last(Types) Weekday
+// Types[1]: Sunday, _.last(Types) Feria
 const getTypeByDayOfWeek = d => _.eq(d, 0) ? Types[1]: _.last(Types);
 
 const convertMomentObjectToIsoDateString = (items = []) => {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1,7 +1,7 @@
 export default {
   "advent": {
     "season": "Advent",
-    "weekday": "{{day}} of the {{week}} week of Advent",
+    "feria": "{{day}} of the {{week}} week of Advent",
     "sunday":  "{{week}} Sunday of Advent"
   },
   "christmastide": {
@@ -17,22 +17,22 @@ export default {
   },
   "ordinaryTime": {
     "season": "Ordinary Time",
-    "weekday": "{{day}} of the {{week}} week of Ordinary Time",
+    "feria": "{{day}} of the {{week}} week of Ordinary Time",
     "sunday": "{{week}} Sunday of Ordinary Time"
   },
   "lent": {
     "season": "Lent",
-    "weekday": "{{day}} of the {{week}} week of Lent",
+    "feria": "{{day}} of the {{week}} week of Lent",
     "sunday": "{{week}} Sunday of Lent",
     "day_after_ash_wed": "{{day}} after Ash Wednesday"
   },
   "holyWeek": {
     "season": "Holy Week",
-    "weekday": "{{day}} of Holy Week"
+    "feria": "{{day}} of Holy Week"
   },
   "eastertide": {
     "season": "Eastertide",
-    "weekday": "{{day}} of the {{week}} week of Easter",
+    "feria": "{{day}} of the {{week}} week of Easter",
     "sunday":  "{{week}} Sunday of Easter",
     "octave": "Easter {{day}}"
   },

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -1,7 +1,7 @@
 export default {
   "advent": {
     "season": "Temps de l'Avent",
-    "weekday": "{{day}} de la {{week}} semaine de l'Avent",
+    "feria": "{{day}} de la {{week}} semaine de l'Avent",
     "sunday":  "{{week}} Dimanche de l'Avant"
   },
   "christmastide": {
@@ -17,22 +17,22 @@ export default {
   },
   "ordinaryTime": {
     "season": "Temps Ordinaire",
-    "weekday": "{{day}} de la {{week}} semaine du Temps Ordinaire",
+    "feria": "{{day}} de la {{week}} semaine du Temps Ordinaire",
     "sunday": "{{week}} Dimanche du Temps Ordinaire"
   },
   "lent": {
     "season": "Carême",
-    "weekday": "{{day}} de la {{week}} semaine du Carême",
+    "feria": "{{day}} de la {{week}} semaine du Carême",
     "sunday": "{{week}} Dimanche du Carême",
     "day_after_ash_wed": "{{day}} des Cendres"
   },
   "holyWeek": {
     "season": "Semaine Sainte",
-    "weekday": "{{day}} Saint"
+    "feria": "{{day}} Saint"
   },
   "eastertide": {
     "season": "Pâques",
-    "weekday": "{{day}} de la {{week}} semaine de Pâques",
+    "feria": "{{day}} de la {{week}} semaine de Pâques",
     "sunday":  "{{week}} Dimanche de Pâques",
     "octave": "{{day}} de Pâques"
   },

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -1,7 +1,7 @@
 export default {
   "advent": {
     "season": "Avvento",
-    "weekday": "{{day}} della {{week}} settimana di Avvento",
+    "feria": "{{day}} della {{week}} settimana di Avvento",
     "sunday":  "{{week}} Domenica di Avvento"
   },
   "christmastide": {
@@ -17,22 +17,22 @@ export default {
   },
   "ordinaryTime": {
     "season": "Tempo Ordinario",
-    "weekday": "{{day}} della {{week}} settimana del Tempo Ordinario",
+    "feria": "{{day}} della {{week}} settimana del Tempo Ordinario",
     "sunday": "{{week}} Domenica del Tempo Ordinario"
   },
   "lent": {
     "season": "Quaresima",
-    "weekday": "{{day}} della {{week}} settimana di Quaresima",
+    "feria": "{{day}} della {{week}} settimana di Quaresima",
     "sunday": "{{week}} Domenica di Quaresima",
     "day_after_ash_wed": "{{day}} dopo Mercoledí delle Ceneri"
   },
   "holyWeek": {
     "season": "Settimana Santa",
-    "weekday": "{{day}} della Settimana Santa"
+    "feria": "{{day}} della Settimana Santa"
   },
   "eastertide": {
     "season": "Pasqua",
-    "weekday": "{{day}} della {{week}} settimana di Pasqua",
+    "feria": "{{day}} della {{week}} settimana di Pasqua",
     "sunday":  "{{week}} Domenica di Pasqua",
     "octave": "{{day}} di Pasqua"
   },

--- a/src/locales/pl.js
+++ b/src/locales/pl.js
@@ -1,7 +1,7 @@
 export default {
   "advent": {
     "season": "Adwentu",
-    "weekday": "{{day}} {{week}} tygodnia Adwentu",
+    "feria": "{{day}} {{week}} tygodnia Adwentu",
     "sunday":  "{{week}} Niedziela Adwentu"
   },
   "christmastide": {
@@ -17,22 +17,22 @@ export default {
   },
   "ordinaryTime": {
     "season": "Zwykła",
-    "weekday": "{{day}} {{week}} tygodnia zwykłego",
+    "feria": "{{day}} {{week}} tygodnia zwykłego",
     "sunday": "{{week}} Niedziela zwykła"
   },
   "lent": {
     "season": "Postu",
-    "weekday": "{{day}} {{week}} tygodnia Wielkiego Postu",
+    "feria": "{{day}} {{week}} tygodnia Wielkiego Postu",
     "sunday": "{{week}} Niedziela Wielkiego Postu",
     "day_after_ash_wed": "{{day}} po Popielcu"
   },
   "holyWeek": {
     "season": "Wielki Tydzień",
-    "weekday": "{{day}} wielkiego tygodnia"
+    "feria": "{{day}} wielkiego tygodnia"
   },
   "eastertide": {
     "season": "Wielkanoc",
-    "weekday": "{{day}} {{week}} tygodnia wielkanocnego",
+    "feria": "{{day}} {{week}} tygodnia wielkanocnego",
     "sunday":  "{{week}} Niedziela Wielkanocna",
     "octave": "{{day}} w oktawie Wielkanocy"
   },

--- a/src/locales/sk.js
+++ b/src/locales/sk.js
@@ -1,7 +1,7 @@
 export default {
   "advent": {
     "season": "Adventné obdobie",
-    "weekday": "{{day}} po {{week}}. adventnej nedeli",
+    "feria": "{{day}} po {{week}}. adventnej nedeli",
     "sunday": "{{week}}. adventná nedeľa"
   },
   "christmastide": {
@@ -17,22 +17,22 @@ export default {
   },
   "ordinaryTime": {
     "season": "Cezročné obdobie",
-    "weekday": "{{day}} {{week}}. týždňa v Cezročnom období",
+    "feria": "{{day}} {{week}}. týždňa v Cezročnom období",
     "sunday": "{{week}}. nedeľa v Cezročnom období"
   },
   "lent": {
     "season": "Pôstne obdobie",
-    "weekday": "{{day}} po {{week}}. pôstnej nedeli",
+    "feria": "{{day}} po {{week}}. pôstnej nedeli",
     "sunday": "{{week}}. pôstna nedeľa",
     "day_after_ash_wed": "{{day}} po Popolcovej strede"
   },
   "holyWeek": {
     "season": "Veľký týždeň",
-    "weekday": "{{day}} vo Veľkom týždni"
+    "feria": "{{day}} vo Veľkom týždni"
   },
   "eastertide": {
     "season": "Veľkonočné obdobie",
-    "weekday": "{{day}} po {{week}.} veľkonočnej nedeli",
+    "feria": "{{day}} po {{week}.} veľkonočnej nedeli",
     "sunday":  "{{week}} veľkonočná nedeľa",
     "octave": "Veľkonočný {{day}}"
   },

--- a/test/01_dates.js
+++ b/test/01_dates.js
@@ -623,14 +623,14 @@ describe('Testing specific liturgical date functions', function() {
 
       });
 
-      it('If first day of the year 2011 is on a weekday (Sat) (i.e. Mon - Sat), Epiphany will be celebrated on the Sunday proceeding', function() {
+      it('If first day of the year 2011 is on a feria (Sat) (i.e. Mon - Sat), Epiphany will be celebrated on the Sunday proceeding', function() {
 
         // First day of 2014 was a Wed, First day of 2015 was a Thurs
         var first = moment.utc({ year: 2011, month: 0, day: 1 }),
             target = moment.utc({ year: 2011, month: 0, day: 1 }).add( 1, 'days').startOf('day'),
             date = Dates.epiphany( 2011 );
 
-        first.day().should.be.equalOneOf([1, 2, 3, 4, 5, 6]); // First day of the year should be a weekday
+        first.day().should.be.equalOneOf([1, 2, 3, 4, 5, 6]); // First day of the year should be a feria
         target.dayOfYear().should.be.eql(2); // Epiphany should be the 4th day of the year
         target.day().should.be.eql( 0 ); // Epiphany should be a Sunday
         date.isSame(target).should.be.eql( true );


### PR DESCRIPTION
This is basically a find and replace in the codebase.

- Feria is more relevant than Weekday, and is the the exact term in the Catholic liturgy.
- It will also avoid possible confusion, since Feria is a day of the week other than Sunday, and a weekday is (by definition) any day on a week.

This will address #88.