### PR TITLE
Drop shrove monday and tuesday from the general calendar

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * Locale files have been renamed to kebab-case with capitalized regions to follow the IETF Language Codes standards and be close to the general conventions in software development for i18n.
 * In locale files, the `general` and `national` parts are now merged in a new `sanctoral` part. This will avoid potential duplicated or missing keys between these 2 parts, particularly when a celebration is move from the general to the national calendar. Also, keys in celebrations and the new sanctoral have been sorted alphabetically. ([#97](https://github.com/romcal/romcal/pull/97))
 * Italian translation has been added in romcal ([#94](https://github.com/romcal/romcal/issues/94)).
+* Drop Shrove Monday and Tuesday from the general calendar ([#90](https://github.com/romcal/romcal/issues/90)).
 * Potential breaking changes:
     - The `WEEKDAY` type is renamed to `FERIA` ([#88](https://github.com/romcal/romcal/issues/88))
 * Fixes:

--- a/README.md
+++ b/README.md
@@ -620,10 +620,6 @@ Usually, this means excluding a celebration defined in `src/calendars/general.js
 }
 ```
 
-An example of this can be seen in the national calendar of Slovakia (`src/calendars/slovakia.js`) where the celebrations of Shrove Monday and Shrove Tuesday are not relevant in the calendar output.
-
-Therefore, the `src/calendars/slovakia.js` redefines these 2 celebration keys with only one property, `drop` with the value of `true` so that they are excluded in the `calendarFor` output.
-
 Note: When defining `drop`, only the key of the celebration is mandatory. Other keys do not have to be defined. `drop` operations also have higher precedence than overriding (meaning, they are run first before prioritization logic).
 
 ## Localizing celebration names <a name="localisation"></a>

--- a/src/calendars/general.js
+++ b/src/calendars/general.js
@@ -1822,19 +1822,6 @@ let dates = year => {
       "type": Types[6],
       "moment": moment.utc({ year: year, month: 11, day: 31 }),
       "data": {}
-    },
-    // Special celebrations
-    {
-      "key": "shroveMonday",
-      "type": _.last( Types ),
-      "moment": Dates.ashWednesday( year ).subtract( 2, 'days'),
-      "data": {}
-    },
-    {
-      "key": "shroveTuesday",
-      "type": _.last( Types ),
-      "moment": Dates.ashWednesday( year ).subtract( 1, 'days'),
-      "data": {}
     }
   ];
 

--- a/src/calendars/italy.js
+++ b/src/calendars/italy.js
@@ -116,15 +116,6 @@ let _dates = [
       "type": Types[5],
       "moment": Dates.pentecostSunday( year ).add( 1, 'days'),
       "data": {}
-    },
-    // Dropped celebrations
-    {
-      "key": "shroveMonday",
-      "drop": true
-    },
-    {
-      "key": "shroveTuesday",
-      "drop": true
     }
   ];
 

--- a/src/calendars/slovakia.js
+++ b/src/calendars/slovakia.js
@@ -226,15 +226,6 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
           "liturgicalColor": LiturgicalColors.WHITE
         }
       }
-    },
-    // Dropped celebrations
-    {
-      "key": "shroveMonday",
-      "drop": true
-    },
-    {
-      "key": "shroveTuesday",
-      "drop": true
     }
   ];
 

--- a/test/05_drop_functionality.js
+++ b/test/05_drop_functionality.js
@@ -35,16 +35,4 @@ describe('Testing "drop" functionality for national calendars', function() {
 
   this.timeout(0);
 
-  it('Shrove Monday and Shrove Tuesday should be dropped from the national calendar of Slovakia', function() {
-    var dates = Calendar.calendarFor({
-      country: 'slovakia', 
-      christmastideIncludesTheSeasonOfEpiphany: true,
-      year: 2015
-    }, true);
-    var shroveDays = _.filter(dates, function(d) {
-      return (_.eq(d.key, 'shroveMonday') || _.eq(d.key, 'shroveTuesday'));
-    });
-    shroveDays.should.be.eql([]);
-  });
-
 });


### PR DESCRIPTION
Shrove monday and tuesday are removed from the general calendar (since the current General Roman Calendar does not have these).

It is still possible to reintroduce them in particular calendars if needed.

Related to #90.