### PR TITLE
In Christian calendars, Sunday is always the first day of the week

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * Locale files have been renamed to kebab-case with capitalized regions to follow the IETF Language Codes standards and be close to the general conventions in software development for i18n.
 * In locale files, the `general` and `national` parts are now merged in a new `sanctoral` part. This will avoid potential duplicated or missing keys between these 2 parts, particularly when a celebration is move from the general to the national calendar. Also, keys in celebrations and the new sanctoral have been sorted alphabetically. ([#97](https://github.com/romcal/romcal/pull/97))
 * Italian translation has been added in romcal ([#94](https://github.com/romcal/romcal/issues/94)).
+* In Christian calendars, Sunday is the first day of the week ([#103](https://github.com/romcal/romcal/issues/103))
 * Potential breaking changes:
     - The `WEEKDAY` type is renamed to `FERIA` ([#88](https://github.com/romcal/romcal/issues/88))
 * Fixes:

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -33,6 +33,12 @@ let setLocale = key => {
   // Set the Moment locale (if unrecognized, will default to 'en')
   moment.locale(localeName);
 
+  // Ensures that the first day is always a Sunday in romcal & Moment.js
+  // - Monday is the first day of the week according to the international standard ISO 8601,
+  //   but in the US, Canada, and Japan, it's counted as the second day of the week.
+  // - In Christian calendars, Sunday is always the first day of the week.
+  moment.updateLocale(localeName, {week: {dow: 0}});
+
   // If a region is specified: append the base language as fallback.
   // Also check if the base language isn't already the default 'en',
   // and if this base language exists in 'src/locales'

--- a/test/01_dates.js
+++ b/test/01_dates.js
@@ -36,6 +36,18 @@ describe('Testing specific liturgical date functions', function() {
 
   this.timeout(0);
 
+  describe('In Christian calendars, Sunday is the first day of the week', function() {
+
+    it('The Solemnity of Epiphany is a Sunday', function() {
+      Romcal.Utils.setLocale('fr');
+      var date1 = Dates.epiphany( 1969 );
+      date1.isoWeekday().should.be.eql( 7 );
+      Romcal.Utils.setLocale('en');
+      var date2 = Dates.epiphany( 1969 );
+      date2.isoWeekday().should.be.eql( 7 );
+    });
+  });
+
   describe('Ash Wednesday occurs on 46 days before Easter Sunday', function() {
 
     it('In 1969, Ash Wednesday was on February 19', function() {


### PR DESCRIPTION
Ensures that the first day is always a Sunday in `romcal` & `Moment.js`
+ Monday is the first day of the week according to the international standard ISO 8601, but in the US, Canada, and Japan, it's counted as the second day of the week.
+ In Christian calendars, Sunday is always the first day of the week.

In locales like French, this was causing an issue where Epiphanie was moved on Monday, instead to be on Sunday.