### PR TITLE
Refactor rank types of celebrations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,13 +1,15 @@
 {
+  "parser": "babel-eslint",
   "plugins": ["node"],
-  "extends": ["eslint:recommended", "plugin:node/recommended"],
+  "extends": ["eslint:recommended"],
   "parserOptions": {
     "sourceType": "module"
   },
   "env": {
-    "es6": true
+    "node": true,
+    "es6": true,
+    "browser": true
   },
   "rules": {
-    "node/exports-style": ["error", "module.exports"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "romcal",
-  "version": "1.3.0-beta2",
+  "version": "1.3.0-beta3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1242,6 +1242,20 @@
       "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
       "dev": true
     },
+    "babel-eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
     "babel-loader": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
@@ -2353,21 +2367,6 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
           "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
           "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.12.2",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.2.tgz",
-          "integrity": "sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
         },
         "semver": {
           "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@babel/node": "^7.7.4",
     "@babel/preset-env": "^7.7.6",
     "@babel/register": "^7.7.4",
+    "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
     "eslint": "^6.7.2",
     "eslint-plugin-node": "^10.0.0",

--- a/src/calendars/argentina.js
+++ b/src/calendars/argentina.js
@@ -9,19 +9,19 @@ let dates = year => {
   let _dates = [
     {
       "key": "blessedLauraVicunaVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 22 }),
       "data": {}
     },
     {
       "key": "ourLadyQueenOfPeace",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 24 }),
       "data": {}
     },
     {
       "key": "saintTuribiusOfMogrovejoBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 27 }),
       "data": {
         "meta": {
@@ -31,7 +31,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfLujanPatronessOfArgentina",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 4, day: 8 }),
       "data": {
         "meta": {
@@ -41,19 +41,19 @@ let dates = year => {
     },
     {
       "key": "saintIsidoreTheFarmer",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 15 }),
       "data": {}
     },
     {
       "key": "saintLuigiOrionePriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {}
     },
     {
       "key": "ourLadyOfItati",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 9 }),
       "data": {
         "meta": {
@@ -63,7 +63,7 @@ let dates = year => {
     },
     {
       "key": "saintsAugustineZhaoRongPriestAndCompanionsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 10 }),
       "data": {
         "meta": {
@@ -75,7 +75,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfMountCarmel",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 16 }),
       "data": {
         "meta": {
@@ -85,13 +85,13 @@ let dates = year => {
     },
     {
       "key": "saintCharbelMakhloufPriestAndHermit",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {}
     },
     {
       "key": "saintFrancisSolanusPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 24 }),
       "data": {
         "meta": {
@@ -101,19 +101,19 @@ let dates = year => {
     },
     {
       "key": "saintRocco",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 16 }),
       "data": {}
     },
     {
       "key": "blessedCeferinoNamuncura",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 26 }),
       "data": {}
     },
     {
       "key": "saintRoseOfLima",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 30 }),
       "data": {
         "meta": {
@@ -123,7 +123,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfMercy",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 24 }),
       "data": {
         "meta": {
@@ -133,7 +133,7 @@ let dates = year => {
     },
     {
       "key": "saintHectorValdivielsoSaezMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 9 }),
       "data": {
         "meta": {
@@ -145,13 +145,13 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfThePillar",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 12 }),
       "data": {}
     },
     {
       "key": "saintsRoqueGonzalezAlfonsoRodriguezOlmedoAndJuanDelCastilloPriestsAndMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 17 }),
       "data": {
         "meta": {
@@ -164,7 +164,7 @@ let dates = year => {
     },
     {
       "key": "saintElizabethOfHungary",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 18 }),
       "data": {
         "meta": {
@@ -174,7 +174,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfGuadalupe",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {
         "meta": {
@@ -185,7 +185,7 @@ let dates = year => {
     // Saturday of the 2nd Week of Easter
     {
       "key": "ourLadyOfTheValley",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": ( y => Dates.divineMercySunday( y ).add( 6, 'days'))( year ),
       "data": {
         "meta": {

--- a/src/calendars/australia.js
+++ b/src/calendars/australia.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintPatrickBishop",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 2, day: 17 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "saintPeterChanelPriestAndMartyrSaintLouisGrignonDeMontfortPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 28 }),
       "data": {
         "meta": {
@@ -32,13 +32,13 @@ let dates = year => {
     },
     {
       "key": "ourLadyHelpOfChristians",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 4, day: 24 }),
       "data": {}
     },
     {
       "key": "blessedPeterToRotMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 7 }),
       "data": {
         "meta": {
@@ -50,7 +50,7 @@ let dates = year => {
     },
     {
       "key": "saintMaryOfTheCrossVirgin",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 7, day: 8 }),
       "data": {
         "meta": {
@@ -60,7 +60,7 @@ let dates = year => {
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/austria.js
+++ b/src/calendars/austria.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {

--- a/src/calendars/belgium.js
+++ b/src/calendars/belgium.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintBrotherMutienMarieReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 30 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "saintAmandMissionary",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 6 }),
       "data": {
         "meta": {
@@ -29,13 +29,13 @@ let dates = year => {
     },
     {
       "key": "saintGertrudeOfNivellesVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 17 }),
       "data": {}
     },
     {
       "key": "saintJulieBilliartVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 8 }),
       "data": {
         "meta": {
@@ -45,7 +45,7 @@ let dates = year => {
     },
     {
       "key": "saintDamienDeVeusterPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 10 }),
       "data": {
         "meta": {
@@ -55,7 +55,7 @@ let dates = year => {
     },
     {
       "key": "saintJulianaOfLiegeVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 7 }),
       "data": {
         "meta": {
@@ -65,7 +65,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyMediatrix",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 31 }),
       "data": {
         "meta": {
@@ -75,7 +75,7 @@ let dates = year => {
     },
     {
       "key": "saintLambertBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 17 }),
       "data": {
         "meta": {
@@ -88,7 +88,7 @@ let dates = year => {
     },
     {
       "key": "saintHubertBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 3 }),
       "data": {
         "meta": {
@@ -98,7 +98,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnBerchmansReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 26 }),
       "data": {
         "meta": {

--- a/src/calendars/bolivia.js
+++ b/src/calendars/bolivia.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintPaulMikiAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 6 }),
       "data": {
         "meta": {
@@ -22,7 +22,7 @@ let dates = year => {
     },
     {
       "key": "saintTuribiusOfMogrovejoBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 23 }),
       "data": {
         "meta": {
@@ -32,13 +32,13 @@ let dates = year => {
     },
     {
       "key": "saintMarianaDeJesusDeParedesVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 25 }),
       "data": {}
     },
     {
       "key": "blessedNazariaIgnaciaMarchReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 23 }),
       "data": {
         "meta": {
@@ -48,13 +48,13 @@ let dates = year => {
     },
     {
       "key": "saintCamillusDeLellisPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 12 }),
       "data": {}
     },
     {
       "key": "saintFrancisSolanusPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 14 }),
       "data": {
         "meta": {
@@ -64,7 +64,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfMountCarmel",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 6, day: 16 }),
       "data": {
         "meta": {
@@ -74,7 +74,7 @@ let dates = year => {
     },
     {
       "key": "saintRoseOfLima",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 23 }),
       "data": {
         "meta": {
@@ -84,13 +84,13 @@ let dates = year => {
     },
     {
       "key": "saintPeterClaverPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 9 }),
       "data": {}
     },
     {
       "key": "saintJohnMaciasReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 18 }),
       "data": {
         "meta": {
@@ -100,19 +100,19 @@ let dates = year => {
     },
     {
       "key": "saintLouisBertrandPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 9 }),
       "data": {}
     },
     {
       "key": "saintMiguelFebresCorderoReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 21 }),
       "data": {}
     },
     {
       "key": "saintAnthonyMaryClaretBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 24 }),
       "data": {
         "meta": {
@@ -122,7 +122,7 @@ let dates = year => {
     },
     {
       "key": "saintMartinDePorresReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 3 }),
       "data": {
         "meta": {
@@ -132,7 +132,7 @@ let dates = year => {
     },
     {
       "key": "saintsRoqueGonzalezAlfonsoRodriguezOlmedoAndJuanDelCastilloPriestsAndMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 19 }),
       "data": {
         "meta": {
@@ -145,7 +145,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfGuadalupe",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {
         "meta": {
@@ -156,7 +156,7 @@ let dates = year => {
     // Thursday after Pentecost
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/bosniaHerzegovina.js
+++ b/src/calendars/bosniaHerzegovina.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintScholasticaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 9 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "blessedAloysiusStepinacBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 10 }),
       "data": {
         "meta": {
@@ -32,7 +32,7 @@ let dates = year => {
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -45,13 +45,13 @@ let dates = year => {
     },
     {
       "key": "blessedOsannaOfCattaroVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 27 }),
       "data": {}
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -65,7 +65,7 @@ let dates = year => {
     },
     {
       "key": "blessedIvanMerz",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 10 }),
       "data": {
         "meta": {
@@ -75,7 +75,7 @@ let dates = year => {
     },
     {
       "key": "saintLeopoldMandicPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 12 }),
       "data": {
         "meta": {
@@ -85,13 +85,13 @@ let dates = year => {
     },
     {
       "key": "blessedMaryOfJesusCrucifiedPetkovicVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 9 }),
       "data": {}
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -104,13 +104,13 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfBistrica",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 13 }),
       "data": {}
     },
     {
       "key": "saintElijahProphet",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 20 }),
       "data": {
         "meta": {
@@ -120,7 +120,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -131,13 +131,13 @@ let dates = year => {
     },
     {
       "key": "saintClementOfOhridAndGorazdBishopsAndCompanions",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 27 }),
       "data": {}
     },
     {
       "key": "blessedAugustinKazoticBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 3 }),
       "data": {
         "titles": [
@@ -147,13 +147,13 @@ let dates = year => {
     },
     {
       "key": "saintRoch",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 16 }),
       "data": {}
     },
     {
       "key": "saintMarkoKrizinPriestAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 8, day: 7 }),
       "data": {
         "meta": {
@@ -166,13 +166,13 @@ let dates = year => {
     },
     {
       "key": "blessedGraziaOfCattaro",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 27 }),
       "data": {}
     },
     {
       "key": "saintNikolaTavelicPriestAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 14 }),
       "data": {
         "meta": {

--- a/src/calendars/brazil.js
+++ b/src/calendars/brazil.js
@@ -5,11 +5,11 @@ import { Dates, Utils } from '../lib';
 import { Titles, Types, LiturgicalColors } from '../constants';
 
 let dates = year => {
-  
+
   let _dates = [
     {
       "key": "saintJoseDeAnchietaPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 9 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "blessedAlbertinaBerkenbrockVirginAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 15 }),
       "data": {
         "meta": {
@@ -32,7 +32,7 @@ let dates = year => {
     },
     {
       "key": "saintPaulinaOfTheAgonizingHeartOfJesusVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 9 }),
       "data": {
         "meta": {
@@ -42,7 +42,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfMountCarmel",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 16 }),
       "data": {
         "meta": {
@@ -52,7 +52,7 @@ let dates = year => {
     },
     {
       "key": "blessedInacioDeAzevedoPriestAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 17 }),
       "data": {
         "meta": {
@@ -65,7 +65,7 @@ let dates = year => {
     },
     {
       "key": "saintRoseOfLima",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 23 }),
       "data": {
         "meta": {
@@ -75,7 +75,7 @@ let dates = year => {
     },
     {
       "key": "blessedsAndreDeSoveralAndAmbrosioFranciscoFerroPriestsAndMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 3 }),
       "data": {
         "meta": {
@@ -88,7 +88,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfAparecidaPatronessOfBrazil",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 9, day: 12 }),
       "data": {
         "meta": {
@@ -98,7 +98,7 @@ let dates = year => {
     },
     {
       "key": "saintAnthonyOfSaintAnneGalvaoFreiGalvaoPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 25 }),
       "data": {
         "meta": {
@@ -108,7 +108,7 @@ let dates = year => {
     },
     {
       "key": "saintsRoqueGonzalezAlfonsoRodriguezOlmedoAndJuanDelCastilloPriestsAndMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 19 }),
       "data": {
         "meta": {
@@ -121,7 +121,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfGuadalupe",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {
         "meta": {
@@ -136,5 +136,5 @@ let dates = year => {
 };
 
 export {
-  dates 
+  dates
 };

--- a/src/calendars/canada.js
+++ b/src/calendars/canada.js
@@ -5,11 +5,11 @@ import { Dates, Utils } from '../lib';
 import { Titles, Types, LiturgicalColors } from '../constants';
 
 let dates = year => {
-  
+
   let _dates = [
     {
       "key": "saintAndreBessetteReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 7 }),
       "data": {
         "meta": {
@@ -19,13 +19,13 @@ let dates = year => {
     },
     {
       "key": "saintRaymondOfPenyafortPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 8 }),
       "data": {}
     },
     {
       "key": "saintMargueriteBourgeoysVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 12 }),
       "data": {
         "meta": {
@@ -35,7 +35,7 @@ let dates = year => {
     },
     {
       "key": "saintJosephSpouseOfTheBlessedVirginMaryPrincipalPatronOfCanada",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 2, day: 19 }),
       "data": {
         "meta": {
@@ -45,61 +45,61 @@ let dates = year => {
     },
     {
       "key": "saintKateriTekakwithaVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 17 }),
       "data": {}
     },
     {
       "key": "blessedMarieAnneBlondinVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 18 }),
       "data": {}
     },
     {
       "key": "ourLadyOfGoodCounsel",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 26 }),
       "data": {}
     },
     {
       "key": "saintMarieOfTheIncarnationReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 30 }),
       "data": {}
     },
     {
       "key": "blessedMarieLeonieParadisVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 4 }),
       "data": {}
     },
     {
       "key": "saintFrancoisDeLavalBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 6 }),
       "data": {}
     },
     {
       "key": "blessedCatherineOfSaintAugustineVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 8 }),
       "data": {}
     },
     {
       "key": "saintEugeneDeMazenodBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 21 }),
       "data": {}
     },
     {
       "key": "blessedLouisZephirinMoreauBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 24 }),
       "data": {}
     },
     {
       "key": "blessedsNykytaBudkaAndVasylVelychkowskyBishopsAndMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 27 }),
       "data": {
         "meta": {
@@ -111,7 +111,7 @@ let dates = year => {
     },
     {
       "key": "saintAnnePatronOfQuebecAndSaintJoachimParentsOfTheBlessedVirginMary",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 26 }),
       "data": {
         "meta": {
@@ -121,13 +121,13 @@ let dates = year => {
     },
     {
       "key": "blessedFredericJanssoonePriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 5 }),
       "data": {}
     },
     {
       "key": "blessedAndreGrassetPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 2 }),
       "data": {
         "meta": {
@@ -139,19 +139,19 @@ let dates = year => {
     },
     {
       "key": "blessedDinaBelangerVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 4 }),
       "data": {}
     },
     {
       "key": "blessedEmilieTavernierGamelinReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 24 }),
       "data": {}
     },
     {
       "key": "saintsJeanDeBrebeufAndIsaacJoguesPriestsAndCompanionsMartyrsSaintPaulOfTheCrossPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 8, day: 26 }),
       "data": {
         "meta": {
@@ -161,13 +161,13 @@ let dates = year => {
     },
     {
       "key": "blessedMarieRoseDurocherVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 6 }),
       "data": {}
     },
     {
       "key": "saintMargueriteDYouvilleReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 16 }),
       "data": {
         "meta": {
@@ -177,13 +177,13 @@ let dates = year => {
     },
     {
       "key": "saintHedwigReligiousOrSaintMargaretMaryAlacoqueVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 20 }),
       "data": {}
     },
     {
       "key": "ourLadyOfGuadalupe",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {
         "meta": {
@@ -198,5 +198,5 @@ let dates = year => {
 };
 
 export {
-  dates 
+  dates
 };

--- a/src/calendars/chile.js
+++ b/src/calendars/chile.js
@@ -9,19 +9,19 @@ let dates = year => {
   let _dates = [
     {
       "key": "blessedLauraVicunaVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 22 }),
       "data": {}
     },
     {
       "key": "blessedPiusIxPope",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 7 }),
       "data": {}
     },
     {
       "key": "ourLadyOfLourdes",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 11 }),
       "data": {
         "meta": {
@@ -31,7 +31,7 @@ let dates = year => {
     },
     {
       "key": "saintsPhilipAndJamesApostles",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 4 }),
       "data": {
         "meta": {
@@ -41,7 +41,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaOfLosAndesVirgin",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 13 }),
       "data": {
         "meta": {
@@ -52,13 +52,13 @@ let dates = year => {
     // Commented because the key and rank is the same as the definition in general.js
     // {
     //   "key": "saintCamillusDeLellisPriest",
-    //   "type": Types[6],
+    //   "type": Types.OPT_MEMORIAL,
     //   "moment": moment.utc({ year: year, month: 6, day: 14 }),
     //   "data": {}
     // },
     {
       "key": "ourLadyOfMountCarmel",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 6, day: 16 }),
       "data": {
         "meta": {
@@ -68,7 +68,7 @@ let dates = year => {
     },
     {
       "key": "saintAlbertoHurtadoPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 18 }),
       "data": {
         "meta": {
@@ -78,7 +78,7 @@ let dates = year => {
     },
     {
       "key": "saintRoseOfLima",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 30 }),
       "data": {
         "meta": {
@@ -88,13 +88,13 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfMercy",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 24 }),
       "data": {}
     },
     {
       "key": "ourLadyOfGuadalupe",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {
         "meta": {
@@ -104,7 +104,7 @@ let dates = year => {
     },
     {
       "key": "jesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 5, day: 16 }),
       "data": {
         "meta": {

--- a/src/calendars/costaRica.js
+++ b/src/calendars/costaRica.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/croatia.js
+++ b/src/calendars/croatia.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "blessedAloysiusStepinacBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 10 }),
       "data": {
         "meta": {
@@ -22,7 +22,7 @@ let dates = year => {
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -33,7 +33,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -47,7 +47,7 @@ let dates = year => {
     },
     {
       "key": "blessedIvanMerz",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 10 }),
       "data": {
         "meta": {
@@ -57,7 +57,7 @@ let dates = year => {
     },
     {
       "key": "saintLeopoldMandicPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 12 }),
       "data": {
         "meta": {
@@ -67,19 +67,19 @@ let dates = year => {
     },
     {
       "key": "saintQuirinusOfSescia",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 4 }),
       "data": {}
     },
     {
       "key": "blessedMaryOfJesusCrucifiedPetkovicVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 9 }),
       "data": {}
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -90,7 +90,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfBistrica",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 13 }),
       "data": {
         "meta": {
@@ -100,7 +100,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -111,7 +111,7 @@ let dates = year => {
     },
     {
       "key": "blessedAugustinKazoticBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 3 }),
       "data": {
         "meta": {
@@ -123,7 +123,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -137,7 +137,7 @@ let dates = year => {
     },
     {
       "key": "saintMarkoKrizinPriestAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 7 }),
       "data": {
         "meta": {
@@ -147,7 +147,7 @@ let dates = year => {
     },
     {
       "key": "saintNikolaTavelicPriestAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 14 }),
       "data": {
         "meta": {

--- a/src/calendars/czechRepublic.js
+++ b/src/calendars/czechRepublic.js
@@ -10,7 +10,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
   let _dates = [
     {
       "key": "ourLadyMotherOfChristianUnity",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 18 }),
       "data": {
         "meta": {
@@ -20,13 +20,13 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "ourLadyMediatrixOfAllGrace",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 8 }),
       "data": {}
     },
     {
       "key": "saintAdalbertBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 23 }),
       "data": {
         "meta": {
@@ -39,7 +39,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -53,13 +53,13 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintSigismundMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 30 }),
       "data": {}
     },
     {
       "key": "saintJohnNepomucenePriestAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {
         "meta": {
@@ -69,7 +69,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintClementMaryHofbauerPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 20 }),
       "data": {
         "meta": {
@@ -79,7 +79,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintZdislava",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 30 }),
       "data": {
         "meta": {
@@ -89,19 +89,19 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintVitusMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 15 }),
       "data": {}
     },
     {
       "key": "saintJohnNeumannBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 19 }),
       "data": {}
     },
     {
       "key": "saintProcopiusAbbot",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 4 }),
       "data": {}
     },
@@ -110,7 +110,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     // https://en.wikipedia.org/wiki/Saints_Cyril_and_Methodius
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ((y, flag) => {
         return flag ? moment.utc({ year: year, month: 1, day: 14 }): moment.utc({ year: year, month: 6, day: 5 });
       })(year, saintsCyrilMonkAndMethodiusBishopOnFeb14),
@@ -123,7 +123,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -134,19 +134,19 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "blessedHroznataMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 14 }),
       "data": {}
     },
     {
       "key": "blessedCeslausAndSaintHyacinthPriests",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 17 }),
       "data": {}
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -159,7 +159,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -173,31 +173,31 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintsBenedyktJanMateuszIsaakAndKrystynMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 25 }),
       "data": {}
     },
     {
       "key": "saintTeresaOfCalcuttaReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 5 }),
       "data": {}
     },
     {
       "key": "saintMelchiorGrodzieckiPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 7 }),
       "data": {}
     },
     {
       "key": "blessedCharlesSpinolaPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 10 }),
       "data": {}
     },
     {
       "key": "saintLudmilaMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 16 }),
       "data": {
         "meta": {
@@ -207,25 +207,25 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintRadimBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 12 }),
       "data": {}
     },
     {
       "key": "blessedKarlOfAustria",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 21 }),
       "data": {}
     },
     {
       "key": "saintWolfgangBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 31 }),
       "data": {}
     },
     {
       "key": "saintAgnesOfBohemiaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 13 }),
       "data": {
         "meta": {
@@ -235,13 +235,13 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintEdmundCampionPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 1 }),
       "data": {}
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/denmark.js
+++ b/src/calendars/denmark.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/england.js
+++ b/src/calendars/england.js
@@ -9,19 +9,19 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintAelredOfRievaulx",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 12 }),
       "data": {}
     },
     {
       "key": "saintWulstanBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 19 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -32,7 +32,7 @@ let dates = year => {
     },
     {
       "key": "saintDavidBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 2, day: 1 }),
       "data": {
         "meta": {
@@ -42,7 +42,7 @@ let dates = year => {
     },
     {
       "key": "saintPatrickBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 2, day: 17 }),
       "data": {
         "meta": {
@@ -55,7 +55,7 @@ let dates = year => {
     // generally the Monday of the Second Week of Easter.
     {
       "key": "saintGeorgeMartyr",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": ( y => {
 
         let holyWeek = Dates.holyWeek( y );
@@ -88,7 +88,7 @@ let dates = year => {
     },
     {
       "key": "saintAdalbertBishopAndMartyrSaintFidelisOfSigmaringenPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 24 }),
       "data": {
         "meta": {
@@ -101,7 +101,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -115,7 +115,7 @@ let dates = year => {
     },
     {
       "key": "theEnglishMartyrs",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 4 }),
       "data": {
         "meta": {
@@ -125,13 +125,13 @@ let dates = year => {
     },
     {
       "key": "stDunstanArchbishopOfCanterbury",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 19 }),
       "data": {}
     },
     {
       "key": "saintBedeTheVenerablePriestAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 25 }),
       "data": {
         "meta": {
@@ -144,7 +144,7 @@ let dates = year => {
     },
     {
       "key": "saintAugustineOfCanterburyBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 27 }),
       "data": {
         "meta": {
@@ -154,7 +154,7 @@ let dates = year => {
     },
     {
       "key": "saintBonifaceBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 5 }),
       "data": {
         "meta": {
@@ -164,7 +164,7 @@ let dates = year => {
     },
     {
       "key": "saintEphraemDeaconDoctorOrSaintColumbaColumCilleAbbot",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 9 }),
       "data": {
         "meta": {
@@ -176,19 +176,19 @@ let dates = year => {
     },
     {
       "key": "saintRichardOfChichesterBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 16 }),
       "data": {}
     },
     {
       "key": "saintAlbanMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 20 }),
       "data": {}
     },
     {
       "key": "saintsJohnFisherBishopAndThomasMoreMartyrs",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 5, day: 22 }),
       "data": {
         "meta": {
@@ -198,19 +198,19 @@ let dates = year => {
     },
     {
       "key": "saintEtheldredaAudreyVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 23 }),
       "data": {}
     },
     {
       "key": "saintOliverPlunketBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 1 }),
       "data": {}
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -221,7 +221,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -232,7 +232,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -246,25 +246,25 @@ let dates = year => {
     },
     {
       "key": "blessedDominicOfTheMotherOfGodDominicBarberiPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 26 }),
       "data": {}
     },
     {
       "key": "saintsMargaretClitherowAnneLineAndMargaretWardMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 30 }),
       "data": {}
     },
     {
       "key": "saintAidanBishopAndTheSaintsOfLindisfarne",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 31 }),
       "data": {}
     },
     {
       "key": "saintGregoryTheGreatPopeAndDoctor",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 8, day: 3 }),
       "data": {
         "meta": {
@@ -277,19 +277,19 @@ let dates = year => {
     },
     {
       "key": "saintCuthbertBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 4 }),
       "data": {}
     },
     {
       "key": "saintTheodoreOfCanterburyBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 19 }),
       "data": {}
     },
     {
       "key": "ourLadyOfWalsingham",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 24 }),
       "data": {
         "meta": {
@@ -299,13 +299,13 @@ let dates = year => {
     },
     {
       "key": "blessedJohnHenryNewmanPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 9 }),
       "data": {}
     },
     {
       "key": "saintPaulinusOfYorkBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 10 }),
       "data": {}
     },
@@ -314,7 +314,7 @@ let dates = year => {
     // Replaces 20th Sunday in Ordinary Time when it falls on a Sunday.
     {
       "key": "peterAndPaulApostles",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": ( y => {
         let date = moment.utc({ year: y, month: 5, day: 29 });
         if ( _.eq(date.day(), 1 )) {
@@ -339,7 +339,7 @@ let dates = year => {
     // Replaces 20th Sunday in Ordinary Time when it falls on a Sunday.
     {
       "key": "assumption",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": ( y => {
         let date = moment.utc({ year: y, month: 7, day: 15 });
         if ( _.eq(date.day(), 1 )) {
@@ -361,49 +361,49 @@ let dates = year => {
     },
     {
       "key": "saintWilfridBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 12 }),
       "data": {}
     },
     {
       "key": "saintEdwardTheConfessor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 13 }),
       "data": {}
     },
     {
       "key": "saintsChadAndCeddBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 26 }),
       "data": {}
     },
     {
       "key": "saintWinefrideVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 3 }),
       "data": {}
     },
     {
       "key": "saintWillibrordBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 7 }),
       "data": {}
     },
     {
       "key": "saintEdmundOfAbingdonBishopOrSaintMargaretOfScotland",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 16 }),
       "data": {}
     },
     {
       "key": "saintElizabethOfHungary",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 17 }),
       "data": {}
     },
     {
       "key": "saintAndrewApostle",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 30 }),
       "data": {
         "meta": {
@@ -418,7 +418,7 @@ let dates = year => {
     // on a Sunday it replaces the Sunday.
     {
       "key": "allSaints",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": ( y => {
         let date = moment.utc({ year: y, month: 10, day: 1 });
         if ( _.eq(date.day(), 6 )) {
@@ -437,7 +437,7 @@ let dates = year => {
     },
     {
       "key": "allSouls",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => {
         let date = moment.utc({ year: y, month: 10, day: 1 });
         if ( _.eq( date.day(), 6 ) ) { // If All Saints is on Saturday
@@ -457,7 +457,7 @@ let dates = year => {
     },
     {
       "key": "saintThomasBecketBishopAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 29 }),
       "data": {
         "meta": {

--- a/src/calendars/finland.js
+++ b/src/calendars/finland.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintHenryBishopAndMartyr",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 0, day: 19 }),
       "data": {
         "meta": {
@@ -22,7 +22,7 @@ let dates = year => {
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -33,7 +33,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -47,7 +47,7 @@ let dates = year => {
     },
     {
       "key": "saintEricIxMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 18 }),
       "data": {
         "meta": {
@@ -57,7 +57,7 @@ let dates = year => {
     },
     {
       "key": "blessedHemmingBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 22 }),
       "data": {
         "meta": {
@@ -67,25 +67,25 @@ let dates = year => {
     },
     {
       "key": "saintUrsulaLedochowskaVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 29 }),
       "data": {}
     },
     {
       "key": "blessedElisabethHesselbaldVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 4 }),
       "data": {}
     },
     {
       "key": "saintJosemariaEscrivaDeBalaguerPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 26 }),
       "data": {}
     },
     {
       "key": "saintCanuteMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 10 }),
       "data": {
         "meta": {
@@ -95,7 +95,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -106,7 +106,7 @@ let dates = year => {
     },
     {
       "key": "saintThorlacBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 20 }),
       "data": {
         "meta": {
@@ -116,7 +116,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -127,7 +127,7 @@ let dates = year => {
     },
     {
       "key": "saintOlafIiMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 29 }),
       "data": {
         "meta": {
@@ -140,7 +140,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -154,7 +154,7 @@ let dates = year => {
     },
     {
       "key": "blessedNicolasStenoBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 25 }),
       "data": {}
     }

--- a/src/calendars/france.js
+++ b/src/calendars/france.js
@@ -9,19 +9,19 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintGenevieveVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 3 }),
       "data": {}
     },
     {
       "key": "saintRemigiusBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 15 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -32,13 +32,13 @@ let dates = year => {
     },
     {
       "key": "saintBernadetteSoubirousVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 18 }),
       "data": {}
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -52,13 +52,13 @@ let dates = year => {
     },
     {
       "key": "saintIvoPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 19 }),
       "data": {}
     },
     {
       "key": "saintJoanOfArcVirginSecondaryPatronessOfFrance",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 30 }),
       "data": {
         "meta": {
@@ -68,19 +68,19 @@ let dates = year => {
     },
     {
       "key": "saintPothinusBishopSaintBlAndinaVirginAndTheirCompanionsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 2 }),
       "data": {}
     },
     {
       "key": "saintClotilde",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 4 }),
       "data": {}
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -91,7 +91,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -102,7 +102,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -116,13 +116,13 @@ let dates = year => {
     },
     {
       "key": "saintCaesariusOfArlesBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 26 }),
       "data": {}
     },
     {
       "key": "saintThereseOfTheChildJesusVirginSecondaryPatronessOfFrance",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 1 }),
       "data": {
         "meta": {

--- a/src/calendars/general.js
+++ b/src/calendars/general.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintsBasilTheGreatAndGregoryNazianzenBishopsAndDoctors",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 2 }),
       "data": {
         "meta": {
@@ -22,19 +22,19 @@ let dates = year => {
     },
     {
       "key": "theMostHolyNameOfJesus",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 3 }),
       "data": {}
     },
     {
       "key": "saintRaymondOfPenyafortPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 7 }),
       "data": {}
     },
     {
       "key": "saintHilaryOfPoitiersBishopAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 13 }),
       "data": {
         "meta": {
@@ -46,7 +46,7 @@ let dates = year => {
     },
     {
       "key": "saintAnthonyOfEgyptAbbot",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 17 }),
       "data": {
         "meta": {
@@ -56,7 +56,7 @@ let dates = year => {
     },
     {
       "key": "saintsFabianPopeAndSebastianMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 20 }),
       "data": {
         "meta": {
@@ -68,7 +68,7 @@ let dates = year => {
     },
     {
       "key": "saintAgnesVirginAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 21 }),
       "data": {
         "meta": {
@@ -81,7 +81,7 @@ let dates = year => {
     },
     {
       "key": "saintVincentDeaconAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 22 }),
       "data": {
         "meta": {
@@ -93,7 +93,7 @@ let dates = year => {
     },
     {
       "key": "saintFrancisDeSalesBishopAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 24 }),
       "data": {
         "meta": {
@@ -109,7 +109,7 @@ let dates = year => {
     // were martyrs.
     {
       "key": "conversionOfSaintPaulApostle",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 0, day: 25 }),
       "data": {
         "meta": {
@@ -119,7 +119,7 @@ let dates = year => {
     },
     {
       "key": "saintsTimothyAndTitusBishops",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 26 }),
       "data": {
         "meta": {
@@ -129,13 +129,13 @@ let dates = year => {
     },
     {
       "key": "saintAngelaMericiVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 27 }),
       "data": {}
     },
     {
       "key": "saintThomasAquinasPriestAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 28 }),
       "data": {
         "meta": {
@@ -148,7 +148,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnBoscoPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 31 }),
       "data": {
         "meta": {
@@ -158,14 +158,14 @@ let dates = year => {
     },
     {
       "key": "saintBlaseBishopAndMartyrSaintAnsgarBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 3 }),
       "data": {
       }
     },
     {
       "key": "saintAgathaVirginAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 5 }),
       "data": {
         "meta": {
@@ -178,7 +178,7 @@ let dates = year => {
     },
     {
       "key": "saintPaulMikiAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 6 }),
       "data": {
         "meta": {
@@ -191,14 +191,14 @@ let dates = year => {
     },
     {
       "key": "saintJeromeEmilianiSaintJosephineBakhitaVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 8 }),
       "data": {
       }
     },
     {
       "key": "saintScholasticaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 10 }),
       "data": {
         "meta": {
@@ -208,13 +208,13 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfLourdes",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 11 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -227,13 +227,13 @@ let dates = year => {
     },
     {
       "key": "sevenHolyFoundersOfTheServiteOrder",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 17 }),
       "data": {}
     },
     {
       "key": "saintPeterDamianBishopAndDoctorOfTheChurch",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 21 }),
       "data": {
         "meta": {
@@ -245,7 +245,7 @@ let dates = year => {
     },
     {
       "key": "chairOfSaintPeterApostle",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 22 }),
       "data": {
         "meta": {
@@ -255,7 +255,7 @@ let dates = year => {
     },
     {
       "key": "saintPolycarpBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 23 }),
       "data": {
         "meta": {
@@ -268,13 +268,13 @@ let dates = year => {
     },
     {
       "key": "saintCasimir",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 4 }),
       "data": {}
     },
     {
       "key": "saintsPerpetuaAndFelicityMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 7 }),
       "data": {
         "meta": {
@@ -287,25 +287,25 @@ let dates = year => {
     },
     {
       "key": "saintJohnOfGodReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 8 }),
       "data": {}
     },
     {
       "key": "saintFrancesOfRomeReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 9 }),
       "data": {}
     },
     {
       "key": "saintPatrickBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 17 }),
       "data": {}
     },
     {
       "key": "saintCyrilOfJerusalemBishopAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 18 }),
       "data": {
         "meta": {
@@ -317,19 +317,19 @@ let dates = year => {
     },
     {
       "key": "saintTuribiusOfMogrovejoBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 23 }),
       "data": {}
     },
     {
       "key": "saintFrancisOfPaolaHermit",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 2 }),
       "data": {}
     },
     {
       "key": "saintIsidoreOfSevilleBishopAndDoctorOfTheChurch",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 4 }),
       "data": {
         "meta": {
@@ -341,13 +341,13 @@ let dates = year => {
     },
     {
       "key": "saintVincentFerrerPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 5 }),
       "data": {}
     },
     {
       "key": "saintJohnBaptistDeLaSallePriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 7 }),
       "data": {
         "meta": {
@@ -357,7 +357,7 @@ let dates = year => {
     },
     {
       "key": "saintStanislausBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 11 }),
       "data": {
         "meta": {
@@ -370,7 +370,7 @@ let dates = year => {
     },
     {
       "key": "saintMartinIPopeAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 13 }),
       "data": {
         "meta": {
@@ -383,7 +383,7 @@ let dates = year => {
     },
     {
       "key": "saintAnselmOfCanterburyBishopAndDoctorOfTheChurch",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 21 }),
       "data": {
         "meta": {
@@ -395,7 +395,7 @@ let dates = year => {
     },
     {
       "key": "saintGeorgeMartyrSaintAdalbertBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 23 }),
       "data": {
         "meta": {
@@ -408,7 +408,7 @@ let dates = year => {
     },
     {
       "key": "saintFidelisOfSigmaringenPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 24 }),
       "data": {
         "meta": {
@@ -421,7 +421,7 @@ let dates = year => {
     },
     {
       "key": "saintMarkTheEvangelist",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 25 }),
       "data": {
         "meta": {
@@ -431,13 +431,13 @@ let dates = year => {
     },
     {
       "key": "saintPeterChanelPriestAndMartyrSaintLouisGrignonDeMontfortPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 28 }),
       "data": {}
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -451,19 +451,19 @@ let dates = year => {
     },
     {
       "key": "saintPiusVPope",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 30 }),
       "data": {}
     },
     {
       "key": "saintJosephTheWorker",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 1 }),
       "data": {}
     },
     {
       "key": "saintAthanasiusBishopAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 2 }),
       "data": {
         "meta": {
@@ -476,7 +476,7 @@ let dates = year => {
     },
     {
       "key": "saintsPhilipAndJamesApostles",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 3 }),
       "data": {
         "meta": {
@@ -486,7 +486,7 @@ let dates = year => {
     },
     {
       "key": "saintsNereusAndAchilleusMartyrsSaintPancrasMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 12 }),
       "data": {
         "meta": {
@@ -498,13 +498,13 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfFatima",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 13 }),
       "data": {}
     },
     {
       "key": "saintMatthiasTheApostle",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 14 }),
       "data": {
         "meta": {
@@ -514,7 +514,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnIPopeAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 18 }),
       "data": {
         "meta": {
@@ -526,13 +526,13 @@ let dates = year => {
     },
     {
       "key": "saintBernardineOfSienaPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 20 }),
       "data": {}
     },
     {
       "key": "saintChristopherMagallanesAndCompanionsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 21 }),
       "data": {
         "meta": {
@@ -544,19 +544,19 @@ let dates = year => {
     },
     {
       "key": "saintRitaOfCascia",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 22 }),
       "data": {}
     },
     {
       "key": "saintBedeTheVenerablePriestAndDoctorSaintGregoryViiPopeSaintMaryMagdaleneDePazziVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 25 }),
       "data": {}
     },
     {
       "key": "saintPhilipNeriPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 26 }),
       "data": {
         "meta": {
@@ -566,13 +566,13 @@ let dates = year => {
     },
     {
       "key": "saintAugustineOfCanterburyBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 27 }),
       "data": {}
     },
     {
       "key": "visitationOfTheBlessedVirginMary",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 31 }),
       "data": {
         "meta": {
@@ -582,7 +582,7 @@ let dates = year => {
     },
     {
       "key": "saintJustinMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 1 }),
       "data": {
         "meta": {
@@ -595,7 +595,7 @@ let dates = year => {
     },
     {
       "key": "saintsMarcellinusAndPeterMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 2 }),
       "data": {
         "meta": {
@@ -607,7 +607,7 @@ let dates = year => {
     },
     {
       "key": "saintsCharlesLwangaAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 3 }),
       "data": {
         "meta": {
@@ -620,7 +620,7 @@ let dates = year => {
     },
     {
       "key": "saintBonifaceBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 5 }),
       "data": {
         "meta": {
@@ -633,7 +633,7 @@ let dates = year => {
     },
     {
       "key": "saintNorbertBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 6 }),
       "data": {
         "meta": {
@@ -643,7 +643,7 @@ let dates = year => {
     },
     {
       "key": "saintEphremDeaconAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 9 }),
       "data": {
         "meta": {
@@ -655,7 +655,7 @@ let dates = year => {
     },
     {
       "key": "saintBarnabasTheApostle",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 11 }),
       "data": {
         "meta": {
@@ -665,7 +665,7 @@ let dates = year => {
     },
     {
       "key": "saintAnthonyOfPaduaPriestAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 13 }),
       "data": {
         "meta": {
@@ -678,13 +678,13 @@ let dates = year => {
     },
     {
       "key": "saintRomualdAbbot",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 19 }),
       "data": {}
     },
     {
       "key": "saintAloysiusGonzagaReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 21 }),
       "data": {
         "meta": {
@@ -694,13 +694,13 @@ let dates = year => {
     },
     {
       "key": "saintPaulinusOfNolaBishopSaintsJohnFisherBishopAndThomasMoreMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 22 }),
       "data": {}
     },
     {
       "key": "saintCyrilOfAlexandriaBishopAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 27 }),
       "data": {
         "meta": {
@@ -712,7 +712,7 @@ let dates = year => {
     },
     {
       "key": "saintIrenaeusBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 28 }),
       "data": {
         "meta": {
@@ -725,13 +725,13 @@ let dates = year => {
     },
     {
       "key": "firstMartyrsOfTheChurchOfRome",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 30 }),
       "data": {}
     },
     {
       "key": "saintThomasTheApostle",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 3 }),
       "data": {
         "meta": {
@@ -741,19 +741,19 @@ let dates = year => {
     },
     {
       "key": "saintElizabethOfPortugal",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 4 }),
       "data": {}
     },
     {
       "key": "saintAnthonyZaccariaPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 5 }),
       "data": {}
     },
     {
       "key": "saintMariaGorettiVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 6 }),
       "data": {
         "meta": {
@@ -766,7 +766,7 @@ let dates = year => {
     },
     {
       "key": "saintsAugustineZhaoRongPriestAndCompanionsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 9 }),
       "data": {
         "meta": {
@@ -778,7 +778,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -789,7 +789,7 @@ let dates = year => {
     },
     {
       "key": "saintHenryBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 13 }),
       "data": {
         "meta": {
@@ -801,13 +801,13 @@ let dates = year => {
     },
     {
       "key": "saintCamillusDeLellisPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 14 }),
       "data": {}
     },
     {
       "key": "saintBonaventureBishopAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 15 }),
       "data": {
         "meta": {
@@ -820,19 +820,19 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfMountCarmel",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 16 }),
       "data": {}
     },
     {
       "key": "saintApollinaris",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 20 }),
       "data": {}
     },
     {
       "key": "saintLawrenceOfBrindisiPriestAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 21 }),
       "data": {
         "meta": {
@@ -845,7 +845,7 @@ let dates = year => {
     // https://github.com/pejulian/romcal/issues/27
     {
       "key": "saintMaryMagdalene",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 22 }),
       "data": {
         "meta": {
@@ -858,7 +858,7 @@ let dates = year => {
     // It will be celebrated on Monday after Pentecost.
     {
       "key": "maryMotherOfTheChurch",
-      "type": Types[5], // Memorial
+      "type": Types.MEMORIAL, // Memorial
       "moment": ( y => Dates.pentecostSunday( y ).add( 1, 'days'))( year ),
       "data": {
         "prioritized": true,
@@ -869,7 +869,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -880,13 +880,13 @@ let dates = year => {
     },
     {
       "key": "saintCharbelMakhloufPriestAndHermit",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 24 }),
       "data": {}
     },
     {
       "key": "saintJamesApostle",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 25 }),
       "data": {
         "meta": {
@@ -896,7 +896,7 @@ let dates = year => {
     },
     {
       "key": "saintsJoachimAndAnne",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 26 }),
       "data": {
         "meta": {
@@ -906,7 +906,7 @@ let dates = year => {
     },
     {
       "key": "saintMartha",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 29 }),
       "data": {
         "meta": {
@@ -916,7 +916,7 @@ let dates = year => {
     },
     {
       "key": "saintPeterChrysologusBishopAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 30 }),
       "data": {
         "meta": {
@@ -928,7 +928,7 @@ let dates = year => {
     },
     {
       "key": "saintIgnatiusOfLoyolaPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 31 }),
       "data": {
         "meta": {
@@ -938,7 +938,7 @@ let dates = year => {
     },
     {
       "key": "saintAlphonsusMariaDeLiguoriBishopAndDoctorOfTheChurch",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 1 }),
       "data": {
         "meta": {
@@ -951,13 +951,13 @@ let dates = year => {
     },
     {
       "key": "saintEusebiusOfVercelliBishopSaintPeterJulianEymardPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 2 }),
       "data": {}
     },
     {
       "key": "saintJeanVianneyTheCureOfArsPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 4 }),
       "data": {
         "meta": {
@@ -967,19 +967,19 @@ let dates = year => {
     },
     {
       "key": "dedicationOfTheBasilicaOfSaintMaryMajor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 5 }),
       "data": {}
     },
     {
       "key": "saintSixtusIiPopeAndCompanionsMartyrsSaintCajetanPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 7 }),
       "data": {}
     },
     {
       "key": "saintDominicPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 8 }),
       "data": {
         "meta": {
@@ -989,7 +989,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -1003,7 +1003,7 @@ let dates = year => {
     },
     {
       "key": "saintLawrenceOfRomeDeaconAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 10 }),
       "data": {
         "meta": {
@@ -1016,7 +1016,7 @@ let dates = year => {
     },
     {
       "key": "saintClareVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 11 }),
       "data": {
         "meta": {
@@ -1026,13 +1026,13 @@ let dates = year => {
     },
     {
       "key": "saintJaneFrancesDeChantalReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 12 }),
       "data": {}
     },
     {
       "key": "saintsPontianPopeAndHippolytusPriestMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 13 }),
       "data": {
         "meta": {
@@ -1044,7 +1044,7 @@ let dates = year => {
     },
     {
       "key": "saintMaximilianMaryKolbePriestAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 14 }),
       "data": {
         "meta": {
@@ -1057,19 +1057,19 @@ let dates = year => {
     },
     {
       "key": "saintStephenOfHungary",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 16 }),
       "data": {}
     },
     {
       "key": "saintJohnEudesPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 19 }),
       "data": {}
     },
     {
       "key": "saintBernardOfClairvauxAbbotAndDoctorOfTheChurch",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 20 }),
       "data": {
         "meta": {
@@ -1082,7 +1082,7 @@ let dates = year => {
     },
     {
       "key": "saintPiusXPope",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 21 }),
       "data": {
         "meta": {
@@ -1092,7 +1092,7 @@ let dates = year => {
     },
     {
       "key": "queenshipOfBlessedVirginMary",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 22 }),
       "data": {
         "meta": {
@@ -1102,13 +1102,13 @@ let dates = year => {
     },
     {
       "key": "saintRoseOfLima",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 23 }),
       "data": {}
     },
     {
       "key": "saintBartholomewTheApostle",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 24 }),
       "data": {
         "meta": {
@@ -1118,13 +1118,13 @@ let dates = year => {
     },
     {
       "key": "saintLouisSaintJosephOfCalasanzPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 25 }),
       "data": {}
     },
     {
       "key": "saintMonica",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 27 }),
       "data": {
         "meta": {
@@ -1134,7 +1134,7 @@ let dates = year => {
     },
     {
       "key": "saintAugustineOfHippoBishopAndDoctorOfTheChurch",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 28 }),
       "data": {
         "meta": {
@@ -1147,7 +1147,7 @@ let dates = year => {
     },
     {
       "key": "theBeheadingOfSaintJohnTheBaptistMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 29 }),
       "data": {
         "meta": {
@@ -1160,7 +1160,7 @@ let dates = year => {
     },
     {
       "key": "saintGregoryTheGreatPopeAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 3 }),
       "data": {
         "meta": {
@@ -1173,7 +1173,7 @@ let dates = year => {
     },
     {
       "key": "birthOfTheBlessedVirginMary",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 8, day: 8 }),
       "data": {
         "meta": {
@@ -1183,7 +1183,7 @@ let dates = year => {
     },
     {
       "key": "saintPeterClaverPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 9 }),
       "data": {
         "meta": {
@@ -1193,13 +1193,13 @@ let dates = year => {
     },
     {
       "key": "holyNameOfTheBlessedVirginMary",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 12 }),
       "data": {}
     },
     {
       "key": "saintJohnChrysostomBishopAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 13 }),
       "data": {
         "meta": {
@@ -1212,7 +1212,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfSorrows",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 15 }),
       "data": {
         "meta": {
@@ -1222,7 +1222,7 @@ let dates = year => {
     },
     {
       "key": "saintsCorneliusPopeAndCyprianBishopMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 16 }),
       "data": {
         "meta": {
@@ -1235,7 +1235,7 @@ let dates = year => {
     },
     {
       "key": "saintRobertBellarmineBishopAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 17 }),
       "data": {
         "meta": {
@@ -1247,7 +1247,7 @@ let dates = year => {
     },
     {
       "key": "saintJanuariusBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 19 }),
       "data": {
         "meta": {
@@ -1259,7 +1259,7 @@ let dates = year => {
     },
     {
       "key": "saintAndrewKimTaegonPriestAndPaulChongHasangAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 20 }),
       "data": {
         "meta": {
@@ -1272,7 +1272,7 @@ let dates = year => {
     },
     {
       "key": "saintMatthewApostleAndEvangelist",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 8, day: 21 }),
       "data": {
         "meta": {
@@ -1282,7 +1282,7 @@ let dates = year => {
     },
     {
       "key": "saintPioOfPietrelcinaPadrePioPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 23 }),
       "data": {
         "meta": {
@@ -1292,7 +1292,7 @@ let dates = year => {
     },
     {
       "key": "saintsCosmasAndDamianMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 26 }),
       "data": {
         "meta": {
@@ -1304,7 +1304,7 @@ let dates = year => {
     },
     {
       "key": "saintVincentDePaulPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 27 }),
       "data": {
         "meta": {
@@ -1314,7 +1314,7 @@ let dates = year => {
     },
     {
       "key": "saintWenceslausMartyrSaintsLawrenceRuizAndCompanionsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 28 }),
       "data": {
         "meta": {
@@ -1326,7 +1326,7 @@ let dates = year => {
     },
     {
       "key": "saintsMichaelGabrielAndRaphaelArchangels",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 8, day: 29 }),
       "data": {
         "meta": {
@@ -1336,7 +1336,7 @@ let dates = year => {
     },
     {
       "key": "saintJeromePriestAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 30 }),
       "data": {
         "meta": {
@@ -1349,7 +1349,7 @@ let dates = year => {
     },
     {
       "key": "saintThereseOfTheChildJesusVirginAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 1 }),
       "data": {
         "meta": {
@@ -1362,7 +1362,7 @@ let dates = year => {
     },
     {
       "key": "guardianAngels",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 2 }),
       "data": {
         "meta": {
@@ -1372,7 +1372,7 @@ let dates = year => {
     },
     {
       "key": "saintFrancisOfAssisi",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 4 }),
       "data": {
         "meta": {
@@ -1382,13 +1382,13 @@ let dates = year => {
     },
     {
       "key": "saintBrunoPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 6 }),
       "data": {},
     },
     {
       "key": "ourLadyOfTheRosary",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 7 }),
       "data": {
         "meta": {
@@ -1398,27 +1398,27 @@ let dates = year => {
     },
     {
       "key": "saintDenisAndCompanionsMartyrsSaintJohnLeonardiPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 9 }),
       "data": {},
     },
     // http://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20140529_decreto-calendario-generale-gxxiii-gpii_en.html
     {
       "key": "popeSaintJohnXXIII",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 11 }),
       "data": {},
     },
     // http://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20140529_decreto-calendario-generale-gxxiii-gpii_en.html
     {
       "key": "popeSaintJohnPaulII",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 22 }),
       "data": {},
     },
     {
       "key": "saintCallistusIPopeAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 14 }),
       "data": {
         "meta": {
@@ -1430,7 +1430,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaOfJesusVirginAndDoctorOfTheChurch",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 15 }),
       "data": {
         "meta": {
@@ -1443,13 +1443,13 @@ let dates = year => {
     },
     {
       "key": "saintHedwigReligiousSaintMargaretMaryAlacoqueVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 16 }),
       "data": {}
     },
     {
       "key": "saintIgnatiusOfAntiochBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 17 }),
       "data": {
         "meta": {
@@ -1462,7 +1462,7 @@ let dates = year => {
     },
     {
       "key": "saintLukeTheEvangelist",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 9, day: 18 }),
       "data": {
         "meta": {
@@ -1472,25 +1472,25 @@ let dates = year => {
     },
     {
       "key": "saintsJeanDeBrebeufAndIsaacJoguesPriestsAndCompanionsMartyrsSaintPaulOfTheCrossPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 19 }),
       "data": {}
     },
     {
       "key": "saintJohnOfCapistranoPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 23 }),
       "data": {}
     },
     {
       "key": "saintAnthonyMaryClaretBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 24 }),
       "data": {}
     },
     {
       "key": "saintsSimonAndJudeApostles",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 9, day: 28 }),
       "data": {
         "meta": {
@@ -1500,7 +1500,7 @@ let dates = year => {
     },
     {
       "key": "allSouls",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 2 }),
       "data": {
         "meta": {
@@ -1510,13 +1510,13 @@ let dates = year => {
     },
     {
       "key": "saintMartinDePorresReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 3 }),
       "data": {}
     },
     {
       "key": "saintCharlesBorromeoBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 4 }),
       "data": {
         "meta": {
@@ -1527,7 +1527,7 @@ let dates = year => {
     // Replaces 32nd Sunday in Ordinary Time when it falls on a Sunday
     {
       "key": "dedicationOfTheLateranBasilica",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 9 }),
       "data": {
         "prioritized": true,
@@ -1538,7 +1538,7 @@ let dates = year => {
     },
     {
       "key": "saintLeoTheGreatPopeAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 10 }),
       "data": {
         "meta": {
@@ -1551,7 +1551,7 @@ let dates = year => {
     },
     {
       "key": "saintMartinOfToursBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 11 }),
       "data": {
         "meta": {
@@ -1561,7 +1561,7 @@ let dates = year => {
     },
     {
       "key": "saintJosaphatBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 12 }),
       "data": {
         "meta": {
@@ -1574,7 +1574,7 @@ let dates = year => {
     },
     {
       "key": "saintAlbertTheGreatBishopAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 15 }),
       "data": {
         "meta": {
@@ -1586,13 +1586,13 @@ let dates = year => {
     },
     {
       "key": "saintMargaretOfScotlandSaintGertrudeTheGreatVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 16 }),
       "data": {}
     },
     {
       "key": "saintElizabethOfHungary",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 17 }),
       "data": {
         "meta": {
@@ -1602,13 +1602,13 @@ let dates = year => {
     },
     {
       "key": "dedicationOfTheBasilicasOfSaintsPeterAndPaulApostles",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 18 }),
       "data": {}
     },
     {
       "key": "presentationOfTheBlessedVirginMary",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 21 }),
       "data": {
         "meta": {
@@ -1618,7 +1618,7 @@ let dates = year => {
     },
     {
       "key": "saintCeciliaVirginAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 22 }),
       "data": {
         "meta": {
@@ -1631,13 +1631,13 @@ let dates = year => {
     },
     {
       "key": "saintClementIPopeAndMartyrSaintColumbanReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 23 }),
       "data": {}
     },
     {
       "key": "saintAndrewDungLacAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 24 }),
       "data": {
         "meta": {
@@ -1650,7 +1650,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfAlexandriaVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 25 }),
       "data": {
         "meta": {
@@ -1662,7 +1662,7 @@ let dates = year => {
     },
     {
       "key": "saintAndrewTheApostle",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 30 }),
       "data": {
         "meta": {
@@ -1672,7 +1672,7 @@ let dates = year => {
     },
     {
       "key": "saintFrancisXavierPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 3 }),
       "data": {
         "meta": {
@@ -1682,7 +1682,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnDamascenePriestAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 4 }),
       "data": {
         "meta": {
@@ -1694,13 +1694,13 @@ let dates = year => {
     },
     {
       "key": "saintNicholasBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 6 }),
       "data": {}
     },
     {
       "key": "saintAmbroseBishopAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 7 }),
       "data": {
         "meta": {
@@ -1713,31 +1713,31 @@ let dates = year => {
     },
     {
       "key": "saintJuanDiegoCuauhtlatoatzin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 9 }),
       "data": {}
     },
     {
       "key": "ourLadyOfLoreto",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 10 }),
       "data": {}
     },
     {
       "key": "saintDamasusIPope",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 11 }),
       "data": {}
     },
     {
       "key": "ourLadyOfGuadalupe",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {}
     },
     {
       "key": "saintLucyOfSyracuseVirginAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 13 }),
       "data": {
         "meta": {
@@ -1750,7 +1750,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnOfTheCrossPriestAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 14 }),
       "data": {
         "meta": {
@@ -1763,7 +1763,7 @@ let dates = year => {
     },
     {
       "key": "saintPeterCanisiusPriestAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 21 }),
       "data": {
         "meta": {
@@ -1775,13 +1775,13 @@ let dates = year => {
     },
     {
       "key": "saintJohnOfKantyPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 23 }),
       "data": {}
     },
     {
       "key": "saintStephenTheFirstMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 26 }),
       "data": {
         "meta": {
@@ -1794,7 +1794,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnTheApostleAndEvangelist",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 27 }),
       "data": {
         "meta": {
@@ -1804,9 +1804,9 @@ let dates = year => {
     },
     {
       "key": "holyInnocentsMartyrs",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 28 }),
-      "data": { 
+      "data": {
         "meta": {
           "liturgicalColor": LiturgicalColors.RED,
           "titles": [
@@ -1817,7 +1817,7 @@ let dates = year => {
     },
     {
       "key": "saintThomasBecketBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 29 }),
       "data": {
         "meta": {
@@ -1829,7 +1829,7 @@ let dates = year => {
     },
     {
       "key": "saintSylvesterIPope",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 31 }),
       "data": {}
     }

--- a/src/calendars/germany.js
+++ b/src/calendars/germany.js
@@ -9,25 +9,25 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintJohnNeumannBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 5 }),
       "data": {}
     },
     {
       "key": "saintValentineOfRaetiaBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 7 }),
       "data": {}
     },
     {
       "key": "saintSeverinusOfNoricumMonk",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 8 }),
       "data": {}
     },
     {
       "key": "saintMeinradMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 21 }),
       "data": {
         "meta": {
@@ -39,19 +39,19 @@ let dates = year => {
     },
     {
       "key": "blessedHenrySusoPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 23 }),
       "data": {}
     },
     {
       "key": "saintRabanusMaurusBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 4 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -62,7 +62,7 @@ let dates = year => {
     },
     {
       "key": "saintMatthiasTheApostle",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 24 }),
       "data": {
         "meta": {
@@ -72,19 +72,19 @@ let dates = year => {
     },
     {
       "key": "saintWalburgaAbbess",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 25 }),
       "data": {}
     },
     {
       "key": "saintFridolinOfSackingenMonk",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 6 }),
       "data": {}
     },
     {
       "key": "saintBrunoBonifaceOfQuerfurtBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 9 }),
       "data": {
         "meta": {
@@ -96,31 +96,31 @@ let dates = year => {
     },
     {
       "key": "saintMatilda",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 14 }),
       "data": {}
     },
     {
       "key": "saintClementMaryHofbauerPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 15 }),
       "data": {}
     },
     {
       "key": "saintGertrudeOfNivellesAbbess",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 17 }),
       "data": {}
     },
     {
       "key": "saintLudgerBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 26 }),
       "data": {}
     },
     {
       "key": "saintLeoIxPopeOrBlessedMarcelCalloMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 19 }),
       "data": {
         "meta": {
@@ -132,13 +132,13 @@ let dates = year => {
     },
     {
       "key": "saintConradOfParzhamReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 21 }),
       "data": {}
     },
     {
       "key": "saintPeterCanisiusPriestAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 27 }),
       "data": {
         "meta": {
@@ -150,7 +150,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -164,7 +164,7 @@ let dates = year => {
     },
     {
       "key": "saintFlorianAndHisCompanionsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 4 }),
       "data": {
         "meta": {
@@ -176,13 +176,13 @@ let dates = year => {
     },
     {
       "key": "saintGotthardBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 5 }),
       "data": {}
     },
     {
       "key": "saintJohnNepomucenePriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {
         "meta": {
@@ -194,13 +194,13 @@ let dates = year => {
     },
     {
       "key": "saintHermannJosephPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 21 }),
       "data": {}
     },
     {
       "key": "saintVitusMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 15 }),
       "data": {
         "meta": {
@@ -212,25 +212,25 @@ let dates = year => {
     },
     {
       "key": "saintBennoOfMeissenBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 16 }),
       "data": {}
     },
     {
       "key": "saintHemmaOfGurk",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 27 }),
       "data": {}
     },
     {
       "key": "saintOttoOfBambergBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 30 }),
       "data": {}
     },
     {
       "key": "visitationOfTheBlessedVirginMary",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 2 }),
       "data": {
         "meta": {
@@ -240,19 +240,19 @@ let dates = year => {
     },
     {
       "key": "saintUlrichOfAugsburg",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 4 }),
       "data": {}
     },
     {
       "key": "saintWillibaldBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 7 }),
       "data": {}
     },
     {
       "key": "saintKilianBishopAndCompanionsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 8 }),
       "data": {
         "meta": {
@@ -264,7 +264,7 @@ let dates = year => {
     },
     {
       "key": "saintsCanuteEricAndOlafMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 10 }),
       "data": {
         "meta": {
@@ -276,7 +276,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -287,13 +287,13 @@ let dates = year => {
     },
     {
       "key": "saintsHenryAndCunigunde",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 13 }),
       "data": {}
     },
     {
       "key": "saintMargaretOfAntiochVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 20 }),
       "data": {
         "meta": {
@@ -305,7 +305,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -315,7 +315,7 @@ let dates = year => {
     },
     {
       "key": "saintChristopherMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 24 }),
       "data": {
         "meta": {
@@ -327,7 +327,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -341,13 +341,13 @@ let dates = year => {
     },
     {
       "key": "saintPaulinusOfTrierBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 31 }),
       "data": {}
     },
     {
       "key": "saintHildegardOfBingenAbbessAndDoctor",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 17 }),
       "data": {
         "meta": {
@@ -359,7 +359,7 @@ let dates = year => {
     },
     {
       "key": "saintLambertBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 18 }),
       "data": {
         "meta": {
@@ -371,7 +371,7 @@ let dates = year => {
     },
     {
       "key": "saintMauriceAndCompanionsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 22 }),
       "data": {
         "meta": {
@@ -383,37 +383,37 @@ let dates = year => {
     },
     {
       "key": "saintsRupertAndVirgiliusOfSalzburgBishops",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 24 }),
       "data": {}
     },
     {
       "key": "saintNicholasOfFlueHermit",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 25 }),
       "data": {}
     },
     {
       "key": "saintLeobaAbbess",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 28 }),
       "data": {}
     },
     {
       "key": "saintGallAbbotAndMissionary",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 16 }),
       "data": {}
     },
     {
       "key": "saintWendelinAbbot",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 20 }),
       "data": {}
     },
     {
       "key": "saintUrsulaAndCompanionsVirginsAndMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 21 }),
       "data": {
         "meta": {
@@ -425,43 +425,43 @@ let dates = year => {
     },
     {
       "key": "saintWolfgangOfRegensburgBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 31 }),
       "data": {}
     },
     {
       "key": "saintHubertOfLiegeBishopOrSaintPirminAbbotAndBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 3 }),
       "data": {}
     },
     {
       "key": "saintLeonardOfNoblacHermit",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 6 }),
       "data": {}
     },
     {
       "key": "saintWillibrordBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 7 }),
       "data": {}
     },
     {
       "key": "saintLeopoldIII",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 15 }),
       "data": {}
     },
     {
       "key": "saintGertrudeTheGreatVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 17 }),
       "data": {}
     },
     {
       "key": "saintElizabethOfHungary",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 19 }),
       "data": {
         "meta": {
@@ -471,19 +471,19 @@ let dates = year => {
     },
     {
       "key": "saintCorbinianBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 20 }),
       "data": {}
     },
     {
       "key": "saintsConradAndGebhardOfConstanceBishops",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 26 }),
       "data": {}
     },
     {
       "key": "saintLuciusOfChurBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 2 }),
       "data": {
         "meta": {
@@ -495,19 +495,19 @@ let dates = year => {
     },
     {
       "key": "saintBarbaraVirginAndMartyrOrBlessedAdolphKolpingPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 4 }),
       "data": {}
     },
     {
       "key": "saintAnnoIiBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 5 }),
       "data": {}
     },
     {
       "key": "saintOdileOfAlsaceAbbess",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 13 }),
       "data": {}
     }

--- a/src/calendars/greece.js
+++ b/src/calendars/greece.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -22,7 +22,7 @@ let dates = year => {
     },
     {
       "key": "saintCyrilOfJerusalemBishopAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 18 }),
       "data": {
         "meta": {
@@ -35,7 +35,7 @@ let dates = year => {
     },
     {
       "key": "saintAdalbertBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 22 }),
       "data": {
         "meta": {
@@ -48,7 +48,7 @@ let dates = year => {
     },
     {
       "key": "saintGeorgeMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 23 }),
       "data": {
         "meta": {
@@ -61,7 +61,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -75,7 +75,7 @@ let dates = year => {
     },
     {
       "key": "saintIrene",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 5 }),
       "data": {
         "meta": {
@@ -85,13 +85,13 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfFatima",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 15 }),
       "data": {}
     },
     {
       "key": "saintCyrilOfAlexandriaBishopAndDoctor",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 27 }),
       "data": {
         "meta": {
@@ -104,7 +104,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -115,7 +115,7 @@ let dates = year => {
     },
     {
       "key": "saintMarina",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 17 }),
       "data": {
         "meta": {
@@ -125,7 +125,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -136,7 +136,7 @@ let dates = year => {
     },
     {
       "key": "saintPantaleon",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 27 }),
       "data": {
         "meta": {
@@ -146,7 +146,7 @@ let dates = year => {
     },
     {
       "key": "saintLydiaOfPhilippi",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 3 }),
       "data": {
         "meta": {
@@ -156,7 +156,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -170,7 +170,7 @@ let dates = year => {
     },
     {
       "key": "saintsCosmasAndDamian",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 26 }),
       "data": {
         "meta": {
@@ -180,7 +180,7 @@ let dates = year => {
     },
     {
       "key": "saintDionysiusTheAreopagite",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 3 }),
       "data": {
         "meta": {
@@ -190,7 +190,7 @@ let dates = year => {
     },
     {
       "key": "saintDemetrius",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 26 }),
       "data": {
         "meta": {
@@ -200,7 +200,7 @@ let dates = year => {
     },
     {
       "key": "presentationOfTheBlessedVirginMary",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 21 }),
       "data": {
         "meta": {
@@ -210,13 +210,13 @@ let dates = year => {
     },
     {
       "key": "saintBarbaraVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 4 }),
       "data": {}
     },
     {
       "key": "saintNicholasBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 6 }),
       "data": {
         "meta": {
@@ -226,7 +226,7 @@ let dates = year => {
     },
     {
       "key": "saintSpyridon",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {
         "meta": {

--- a/src/calendars/guatemala.js
+++ b/src/calendars/guatemala.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
   {
     "key": "ourLordJesusChristTheEternalHighPriest",
-    "type": Types[4],
+    "type": Types.FEAST,
     "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
     "data": {
       "meta": {

--- a/src/calendars/hungary.js
+++ b/src/calendars/hungary.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintMargaretOfHungary",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 0, day: 18 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -30,7 +30,7 @@ let dates = year => {
     },
     {
       "key": "saintMatthiasTheApostle",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 24 }),
       "data": {
         "meta": {
@@ -40,7 +40,7 @@ let dates = year => {
     },
     {
       "key": "saintAdalbertBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 23 }),
       "data": {
         "meta": {
@@ -53,7 +53,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -67,7 +67,7 @@ let dates = year => {
     },
     {
       "key": "saintFlorianMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 4 }),
       "data": {
         "meta": {
@@ -79,13 +79,13 @@ let dates = year => {
     },
     {
       "key": "blessedGisela",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 7 }),
       "data": {}
     },
     {
       "key": "blessedSaraSalkahaziVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 11 }),
       "data": {
         "meta": {
@@ -97,7 +97,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnNepomucenePriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {
         "meta": {
@@ -109,7 +109,7 @@ let dates = year => {
     },
     {
       "key": "blessedVilmosAporBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 23 }),
       "data": {
         "meta": {
@@ -121,19 +121,19 @@ let dates = year => {
     },
     {
       "key": "ourLadyHelpOfChristians",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 24 }),
       "data": {}
     },
     {
       "key": "transferOfTheRelicsOfSaintStephen",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 30 }),
       "data": {}
     },
     {
       "key": "saintAgnesOfBohemiaVirgin",
-      "type": Types[5], // Memorial
+      "type": Types.MEMORIAL, // Memorial
       "moment": moment.utc({ year: year, month: 5, day: 8 }), // 8th of June
       "data": {
         "meta": {
@@ -144,7 +144,7 @@ let dates = year => {
     // Moved to the congregational calendar (Society of Saint Francis de Sales (Salesian Congregation)
     // {
     //   "key": "blessedIstvanSandorMartyr",
-    //   "type": Types[6],
+    //   "type": Types.OPT_MEMORIAL,
     //   "moment": moment.utc({ year: year, month: 5, day: 8 }),
     //   "data": {
     //     "meta": {
@@ -156,7 +156,7 @@ let dates = year => {
     // },
     {
       "key": "saintLadislaus",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 5, day: 27 }),
       "data": {
         "meta": {
@@ -166,7 +166,7 @@ let dates = year => {
     },
     {
       "key": "visitationOfTheBlessedVirginMary",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 2 }),
       "data": {
         "meta": {
@@ -176,7 +176,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -187,13 +187,13 @@ let dates = year => {
     },
     {
       "key": "saintsAndrewZorardAndBenedictHermits",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 17 }),
       "data": {}
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -204,13 +204,13 @@ let dates = year => {
     },
     {
       "key": "saintKingaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 24 }),
       "data": {}
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -224,25 +224,25 @@ let dates = year => {
     },
     {
       "key": "blessedInnocentXiPope",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 13 }),
       "data": {}
     },
     {
       "key": "saintStephenOfHungary",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 7, day: 20 }),
       "data": {}
     },
     {
       "key": "saintTeresaOfCalcuttaReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 5 }),
       "data": {}
     },
     {
       "key": "saintsMarkoKrizinMelicharGrodeckiAndStephenPongracPriestsAndMartyrs",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 8, day: 7 }),
       "data": {
         "meta": {
@@ -252,7 +252,7 @@ let dates = year => {
     },
     {
       "key": "saintGerardBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 8, day: 24 }),
       "data": {
         "meta": {
@@ -262,7 +262,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfHungary",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 9, day: 8 }),
       "data": {
         "meta": {
@@ -272,13 +272,13 @@ let dates = year => {
     },
     {
       "key": "saintMaurusBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 25 }),
       "data": {}
     },
     {
       "key": "blessedTheodoreRomzhaBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 31 }),
       "data": {
         "meta": {
@@ -290,7 +290,7 @@ let dates = year => {
     },
     {
       "key": "saintEmeric",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 4 }),
       "data": {
         "meta": {
@@ -300,7 +300,7 @@ let dates = year => {
     },
     {
       "key": "hungarianSaintsAndBlesseds",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 13 }),
       "data": {}
     }

--- a/src/calendars/india.js
+++ b/src/calendars/india.js
@@ -9,19 +9,19 @@ let dates = year => {
   let _dates = [
     {
       "key": "blessedKuriakoseEliasChavaraPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 3 }),
       "data": {}
     },
     {
       "key": "blessedJosephVazPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 16 }),
       "data": {}
     },
     {
       "key": "saintJohnDeBritoPriestAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 4 }),
       "data": {
         "meta": {
@@ -34,7 +34,7 @@ let dates = year => {
     },
     {
       "key": "saintGonsaloGarciaMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 6 }),
       "data": {
         "meta": {
@@ -47,13 +47,13 @@ let dates = year => {
     },
     {
       "key": "blessedMariaTheresaChiramelVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 8 }),
       "data": {}
     },
     {
       "key": "saintThomasTheApostle",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 6, day: 3 }),
       "data": {
         "meta": {
@@ -63,7 +63,7 @@ let dates = year => {
     },
     {
       "key": "saintAlphonsaOfTheImmaculateConceptionVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 28 }),
       "data": {
         "meta": {
@@ -73,7 +73,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaOfCalcuttaReligious",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 8, day: 5 }),
       "data": {
         "meta": {
@@ -83,7 +83,7 @@ let dates = year => {
     },
     {
       "key": "saintFrancisXavierPriest",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 11, day: 3 }),
       "data": {
         "meta": {

--- a/src/calendars/ireland.js
+++ b/src/calendars/ireland.js
@@ -9,13 +9,13 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintMunchinBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 3 }),
       "data": {}
     },
     {
       "key": "saintItaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 15 }),
       "data": {
         "meta": {
@@ -25,19 +25,19 @@ let dates = year => {
     },
     {
       "key": "saintFursaAbbotAndMissionary",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 16 }),
       "data": {}
     },
     {
       "key": "saintAidanBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 30 }),
       "data": {}
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 1 }),
       "data": {
         "meta": {
@@ -48,19 +48,19 @@ let dates = year => {
     },
     {
       "key": "saintMelBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 7 }),
       "data": {}
     },
     {
       "key": "saintGobnaitVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 11 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -71,37 +71,37 @@ let dates = year => {
     },
     {
       "key": "saintFintan",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 17 }),
       "data": {}
     },
     {
       "key": "saintDavidBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 1 }),
       "data": {}
     },
     {
       "key": "saintKieranBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 5 }),
       "data": {}
     },
     {
       "key": "saintSenanBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 8 }),
       "data": {}
     },
     {
       "key": "saintAengusOengusBishopAndAbbot",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 11 }),
       "data": {}
     },
     {
       "key": "saintPatrickBishop",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 2, day: 17 }),
       "data": {
         "meta": {
@@ -111,37 +111,37 @@ let dates = year => {
     },
     {
       "key": "saintEndaAbbot",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 21 }),
       "data": {}
     },
     {
       "key": "saintMacartanBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 24 }),
       "data": {}
     },
     {
       "key": "saintCeallachCelsusBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 1 }),
       "data": {}
     },
     {
       "key": "saintMolaiseLaisrenLaserianBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 18 }),
       "data": {}
     },
     {
       "key": "saintAsicusBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 27 }),
       "data": {}
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -155,37 +155,37 @@ let dates = year => {
     },
     {
       "key": "saintConlethBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 4 }),
       "data": {}
     },
     {
       "key": "blessedEdmundIgnatiusRiceReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 5 }),
       "data": {}
     },
     {
       "key": "saintComgallAbbot",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 10 }),
       "data": {}
     },
     {
       "key": "saintCarthageBishopMochuta",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 15 }),
       "data": {}
     },
     {
       "key": "saintBrendanAbbot",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {}
     },
     {
       "key": "saintKevinAbbot",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 3 }),
       "data": {
         "meta": {
@@ -195,19 +195,19 @@ let dates = year => {
     },
     {
       "key": "saintJarlathBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 6 }),
       "data": {}
     },
     {
       "key": "saintColmanOfDromoreBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 7 }),
       "data": {}
     },
     {
       "key": "saintColumbaAbbotAndMissionary",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 5, day: 9 }),
       "data": {
         "meta": {
@@ -217,13 +217,13 @@ let dates = year => {
     },
     {
       "key": "saintDavnetVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 14 }),
       "data": {}
     },
     {
       "key": "blessedIrishMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 20 }),
       "data": {
         "meta": {
@@ -236,7 +236,7 @@ let dates = year => {
     },
     {
       "key": "saintOliverPlunkettBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 1 }),
       "data": {
         "meta": {
@@ -249,19 +249,19 @@ let dates = year => {
     },
     {
       "key": "saintMoninneVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 6 }),
       "data": {}
     },
     {
       "key": "saintMaelruainMaolruainVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 7 }),
       "data": {}
     },
     {
       "key": "saintKillianBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 8 }),
       "data": {
         "meta": {
@@ -273,7 +273,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -284,13 +284,13 @@ let dates = year => {
     },
     {
       "key": "saintDeclanBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 24 }),
       "data": {}
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -304,19 +304,19 @@ let dates = year => {
     },
     {
       "key": "saintMuiredachBishopSaintAttractaVirginOrSaintLeliaVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 12 }),
       "data": {}
     },
     {
       "key": "saintFachtnaBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 13 }),
       "data": {}
     },
     {
       "key": "ourLadyOfKnock",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 17 }),
       "data": {
         "meta": {
@@ -326,31 +326,31 @@ let dates = year => {
     },
     {
       "key": "saintEugeneEoghanBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 23 }),
       "data": {}
     },
     {
       "key": "saintFiacreMonk",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 30 }),
       "data": {}
     },
     {
       "key": "saintAidanOfLindisfarneBishopAndMissionary",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 31 }),
       "data": {}
     },
     {
       "key": "saintMacNissiBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 4 }),
       "data": {}
     },
     {
       "key": "saintCiaranAbbot",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 9 }),
       "data": {
         "meta": {
@@ -360,13 +360,13 @@ let dates = year => {
     },
     {
       "key": "saintAilbeBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 12 }),
       "data": {}
     },
     {
       "key": "saintPioOfPietralcina",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 23 }),
       "data": {
         "meta": {
@@ -376,49 +376,49 @@ let dates = year => {
     },
     {
       "key": "saintFinbarrBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 25 }),
       "data": {}
     },
     {
       "key": "blessedColumbaMarmionPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 3 }),
       "data": {}
     },
     {
       "key": "blessedJohnHenryNewmanPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 9 }),
       "data": {}
     },
     {
       "key": "saintCaniceAbbot",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 11 }),
       "data": {}
     },
     {
       "key": "saintGallAbbotAndMissionary",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 16 }),
       "data": {}
     },
     {
       "key": "saintOtteranMonk",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 27 }),
       "data": {}
     },
     {
       "key": "saintColmanOfKilmacduaghBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 29 }),
       "data": {}
     },
     {
       "key": "saintMalachyBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 3 }),
       "data": {
         "meta": {
@@ -428,7 +428,7 @@ let dates = year => {
     },
     {
       "key": "allSaintsOfIreland",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 6 }),
       "data": {
         "prioritized": true,
@@ -439,19 +439,19 @@ let dates = year => {
     },
     {
       "key": "saintWillibrordBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 7 }),
       "data": {}
     },
     {
       "key": "saintLaurenceOTooleBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 14 }),
       "data": {}
     },
     {
       "key": "saintColumbanAbbotAndMissionary",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 23 }),
       "data": {
         "meta": {
@@ -461,31 +461,31 @@ let dates = year => {
     },
     {
       "key": "saintColmanOfCloyneBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 25 }),
       "data": {}
     },
     {
       "key": "saintFergalBishopAndMissionary",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 27 }),
       "data": {}
     },
     {
       "key": "saintFinnianOfClonardBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {}
     },
     {
       "key": "saintFlannanBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 18 }),
       "data": {}
     },
     {
       "key": "saintFachananOfKilfenoraBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 20 }),
       "data": {}
     }

--- a/src/calendars/italy.js
+++ b/src/calendars/italy.js
@@ -9,7 +9,7 @@ let dates = year => {
 let _dates = [
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -20,7 +20,7 @@ let _dates = [
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -34,7 +34,7 @@ let _dates = [
     },
     {
       "key": "saintNorbertBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 6 }),
       "data": {
         "meta": {
@@ -44,13 +44,13 @@ let _dates = [
     },
     {
       "key": "saintBarnabasTheApostle",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 11 }),
       "data": {}
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -61,7 +61,7 @@ let _dates = [
     },
     {
       "key": "saintMaryMagdalene",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 22 }),
       "data": {
         "meta": {
@@ -71,13 +71,13 @@ let _dates = [
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {}
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -91,7 +91,7 @@ let _dates = [
     },
     {
       "key": "saintFrancisOfAssisi",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 9, day: 4 }),
       "data": {
         "meta": {
@@ -101,19 +101,19 @@ let _dates = [
     },
     {
       "key": "popeSaintJohnXXIII",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 11 }),
       "data": {}
     },
     {
       "key": "popeSaintJohnPaulII",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 22 }),
       "data": {}
     },
     {
       "key": "maryMotherOfTheChurch",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": Dates.pentecostSunday( year ).add( 1, 'days'),
       "data": {}
     }

--- a/src/calendars/japan.js
+++ b/src/calendars/japan.js
@@ -5,11 +5,11 @@ import { Dates, Utils } from '../lib';
 import { Titles, Types, LiturgicalColors } from '../constants';
 
 let dates = year => {
-  
+
   let _dates = [
     {
       "key": "saintPaulMikiAndCompanionsMartyrs",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 6 }),
       "data": {
         "meta": {
@@ -22,13 +22,13 @@ let dates = year => {
     },
     {
       "key": "discoveryOfTheHiddenChristians",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 17 }),
       "data": {}
     },
     {
       "key": "blessedPeterKibePriestAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 1 }),
       "data": {
         "meta": {
@@ -41,7 +41,7 @@ let dates = year => {
     },
     {
       "key": "205BlessedMartyrsOfJapan",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 10 }),
       "data": {
         "meta": {
@@ -51,7 +51,7 @@ let dates = year => {
     },
     {
       "key": "saintThomasRokuzayemonPriestAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 28 }),
       "data": {
         "meta": {
@@ -61,7 +61,7 @@ let dates = year => {
     },
     {
       "key": "saintFrancisXavierPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 3 }),
       "data": {
         "meta": {
@@ -76,5 +76,5 @@ let dates = year => {
 };
 
 export {
-  dates 
+  dates
 };

--- a/src/calendars/lebanon.js
+++ b/src/calendars/lebanon.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintBarbaraVirginAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 4 }),
       "data": {
         "meta": {
@@ -22,31 +22,31 @@ let dates = year => {
     },
     {
       "key": "saintNicholasBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 6 }),
       "data": {}
     },
     {
       "key": "saintCharbelMakhloufPriestAndHermit",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 24 }),
       "data": {}
     },
     {
       "key": "saintMaroun",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 9 }),
       "data": {}
     },
     {
       "key": "saintRafqaRebeccaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 23 }),
       "data": {}
     },
     {
       "key": "saintGeorgeMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 23 }),
       "data": {
         "meta": {
@@ -59,7 +59,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfLebanon",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 1 }),
       "data": {}
     }
@@ -70,5 +70,5 @@ let dates = year => {
 };
 
 export {
-  dates 
+  dates
 };

--- a/src/calendars/lithuania.js
+++ b/src/calendars/lithuania.js
@@ -9,13 +9,13 @@ let dates = year => {
   let _dates = [
     {
       "key": "blessedJerzyMatulewiczBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 27 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -27,13 +27,13 @@ let dates = year => {
     },
     {
       "key": "saintCasimir",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 2, day: 4 }),
       "data": {}
     },
     {
       "key": "saintBrunoBonifaceOfQuerfurtBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 9 }),
       "data": {
         "meta": {
@@ -45,7 +45,7 @@ let dates = year => {
     },
     {
       "key": "saintAdalbertBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 23 }),
       "data": {
         "meta": {
@@ -58,7 +58,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -71,7 +71,7 @@ let dates = year => {
     },
     {
       "key": "saintAndrewBobolaPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {
         "meta": {
@@ -83,13 +83,13 @@ let dates = year => {
     },
     {
       "key": "ourLadyMotherOfMercy",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 10, day: 16 }),
       "data": {}
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -101,7 +101,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -112,7 +112,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -126,25 +126,25 @@ let dates = year => {
     },
     {
       "key": "saintRocco",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 16 }),
       "data": {}
     },
     {
       "key": "saintHyacinthPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 17 }),
       "data": {}
     },
     {
       "key": "birthOfTheBlessedVirginMary",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 8, day: 8 }),
       "data": {}
     },
     {
       "key": "saintFaustinaKowalskaVirginAndReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 5 }),
       "data": {}
     }

--- a/src/calendars/malta.js
+++ b/src/calendars/malta.js
@@ -9,19 +9,19 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintPubliusBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 22 }),
       "data": {}
     },
     {
       "key": "shipwreckOfSaintPaulApostle",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 1, day: 10 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -34,19 +34,19 @@ let dates = year => {
     },
     {
       "key": "blessedMariaAdeodataPisaniVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 25 }),
       "data": {}
     },
     {
       "key": "ourLadyOfSorrows",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 15 }),
       "data": {}
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -59,37 +59,37 @@ let dates = year => {
     },
     {
       "key": "saintPiusVPope",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 30 }),
       "data": {}
     },
     {
       "key": "saintGeorgePrecaPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 9 }),
       "data": {}
     },
     {
       "key": "blessedNazjuFalzon",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 1 }),
       "data": {}
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {}
     },
     {
       "key": "ourLadyOfMountCarmel",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 16 }),
       "data": {}
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -100,7 +100,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -114,7 +114,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfAlexandriaVirginAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 25 }),
       "data": {
         "meta": {

--- a/src/calendars/mexico.js
+++ b/src/calendars/mexico.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintFelipeDeJesusPriestAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 0, day: 22 }),
       "data": {
         "meta": {
@@ -22,13 +22,13 @@ let dates = year => {
     },
     {
       "key": "blessedSebastianDeAparicioReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 25 }),
       "data": {}
     },
     {
       "key": "saintChristopherMagallanesAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 21 }),
       "data": {
         "meta": {
@@ -41,13 +41,13 @@ let dates = year => {
     },
     {
       "key": "saintMariaDeJesusSacramentadoVenegasVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 30 }),
       "data": {}
     },
     {
       "key": "blessedBartolomeLaurelReligiousAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 16 }),
       "data": {
         "meta": {
@@ -59,7 +59,7 @@ let dates = year => {
     },
     {
       "key": "blessedsPedroZunigaAndLuisFloresPriestsAndMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 16 }),
       "data": {
         "meta": {
@@ -71,25 +71,25 @@ let dates = year => {
     },
     {
       "key": "blessedJuniperoSerraPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 26 }),
       "data": {}
     },
     {
       "key": "saintJoseMariaDeYermoPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 19 }),
       "data": {}
     },
     {
       "key": "saintRafaelGuizarYValenciaBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 24 }),
       "data": {}
     },
     {
       "key": "blessedMiguelAgustinProPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 23 }),
       "data": {
         "meta": {
@@ -101,19 +101,19 @@ let dates = year => {
     },
     {
       "key": "saintJuanDiego",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 9 }),
       "data": {}
     },
     {
       "key": "ourLadyOfGuadalupe",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {}
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/netherlands.js
+++ b/src/calendars/netherlands.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/newZealand.js
+++ b/src/calendars/newZealand.js
@@ -9,13 +9,13 @@ let dates = year => {
   let _dates = [
     {
       "key": "waitangiDay",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 6 }),
       "data": {}
     },
     {
       "key": "saintPaulMikiAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 7 }),
       "data": {
         "meta": {
@@ -28,25 +28,25 @@ let dates = year => {
     },
     {
       "key": "saintPatrickBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 2, day: 17 }),
       "data": {}
     },
     {
       "key": "saintMarkApostle",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 26 }),
       "data": {}
     },
     {
       "key": "saintLouisGrignonDeMontfortPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 27 }),
       "data": {}
     },
     {
       "key": "saintPeterChanelPriestAndMartyrSaintLouisGrignonDeMontfortPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 28 }),
       "data": {
         "meta": {
@@ -59,25 +59,25 @@ let dates = year => {
     },
     {
       "key": "ourLadyHelpOfChristians",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 24 }),
       "data": {}
     },
     {
       "key": "saintMarcellinChampagnatPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 6 }),
       "data": {}
     },
     {
       "key": "saintDominicPriest/SaintSixtusIiPopeAndCompanionsMartyrsSaintCajetanPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 7 }),
       "data": {}
     },
     {
       "key": "saintMaryMacKillopVirgin",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 8 }),
       "data": {}
     }

--- a/src/calendars/norway.js
+++ b/src/calendars/norway.js
@@ -9,13 +9,13 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintThorfinnBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 8 }),
       "data": {}
     },
     {
       "key": "saintHenryBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 19 }),
       "data": {
         "meta": {
@@ -28,13 +28,13 @@ let dates = year => {
     },
     {
       "key": "saintEysteinnBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 26 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -46,7 +46,7 @@ let dates = year => {
     },
     {
       "key": "saintMagnusMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {
         "meta": {
@@ -59,7 +59,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -72,7 +72,7 @@ let dates = year => {
     },
     {
       "key": "saintEricIxMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 18 }),
       "data": {
         "meta": {
@@ -85,7 +85,7 @@ let dates = year => {
     },
     {
       "key": "saintSunnivaVirginAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 8 }),
       "data": {
         "meta": {
@@ -98,7 +98,7 @@ let dates = year => {
     },
     {
       "key": "saintCanuteMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 10 }),
       "data": {
         "meta": {
@@ -111,7 +111,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -123,19 +123,19 @@ let dates = year => {
     },
     {
       "key": "saintSwithunBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 15 }),
       "data": {}
     },
     {
       "key": "saintThorlacBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 20 }),
       "data": {}
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -146,7 +146,7 @@ let dates = year => {
     },
     {
       "key": "saintOlafIiMartyr",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 4, day: 29 }),
       "data": {
         "meta": {
@@ -159,7 +159,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -173,7 +173,7 @@ let dates = year => {
     },
     {
       "key": "blessedNicolasStenoBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 25 }),
       "data": {}
     }

--- a/src/calendars/panama.js
+++ b/src/calendars/panama.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
   {
     "key": "ourLordJesusChristTheEternalHighPriest",
-    "type": Types[4],
+    "type": Types.FEAST,
     "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
     "data": {
       "meta": {

--- a/src/calendars/paraguay.js
+++ b/src/calendars/paraguay.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
   {
     "key": "ourLordJesusChristTheEternalHighPriest",
-    "type": Types[4],
+    "type": Types.FEAST,
     "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
     "data": {
       "meta": {

--- a/src/calendars/peru.js
+++ b/src/calendars/peru.js
@@ -9,73 +9,73 @@ let dates = year => {
   let _dates = [
     {
       "key": "findingOfTheHolyCross",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 3 }),
       "data": {}
     },
     {
       "key": "ourLadyHelpOfChristians",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 24 }),
       "data": {}
     },
     {
       "key": "saintMarianaDeJesusDeParedesVirgin",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 26 }),
       "data": {}
     },
     {
       "key": "saintFrancisSolanusPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 14 }),
       "data": {}
     },
     {
       "key": "ourLadyOfPeace",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 28 }),
       "data": {}
     },
     {
       "key": "saintRoseOfLima",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 7, day: 23 }),
       "data": {}
     },
     {
       "key": "saintJohnMaciasReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 8, day: 18 }),
       "data": {}
     },
     {
       "key": "ourLadyOfMercy",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 24 }),
       "data": {}
     },
     {
       "key": "ourLordOfMiracles",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 9, day: 28 }),
       "data": {}
     },
     {
       "key": "saintMartinDePorresReligious",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 10, day: 3 }),
       "data": {}
     },
     {
       "key": "ourLadyOfGuadalupe",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {}
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/philippines.js
+++ b/src/calendars/philippines.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "santoNinoInfantJesus",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": function() {
         // Third Sunday of January: Santo Niño (Holy Child Jesus)
         let firstDay = moment.utc({ year: year, month: 0, day: 1 });
@@ -25,7 +25,7 @@ let dates = year => {
     },
     {
       "key": "saintPaulMikiAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 6 }),
       "data": {
         "meta": {
@@ -38,7 +38,7 @@ let dates = year => {
     },
     {
       "key": "saintPedroCalungsodMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 2 }),
       "data": {
         "meta": {
@@ -51,25 +51,25 @@ let dates = year => {
     },
     {
       "key": "saintIsidoreTheFarmer",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 15 }),
       "data": {}
     },
     {
       "key": "saintRoch",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 16 }),
       "data": {}
     },
     {
       "key": "saintEzekielMorenoBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 19 }),
       "data": {}
     },
     {
       "key": "saintLorenzoRuizAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 28 }),
       "data": {
         "meta": {
@@ -82,7 +82,7 @@ let dates = year => {
     },
     {
       "key": "immaculateConceptionOfTheBlessedVirginMaryPrincipalPatronessOfThePhilippines",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 11, day: 8 }),
       "data": {}
     }

--- a/src/calendars/poland.js
+++ b/src/calendars/poland.js
@@ -16,37 +16,37 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintJozefSebastianPelczar",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 19 }),
       "data": {}
     },
     {
       "key": "saintVincentPallottiPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 22 }),
       "data": {}
     },
     {
       "key": "blessedVincentLewoniukAndCompanionsMartyrsOfPratulin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 23 }),
       "data": {}
     },
     {
       "key": "blessedJerzyMatulewiczBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 27 }),
       "data": {}
     },
     {
       "key": "blessedBoleslawaMariaLamentVirginAndSaintAngelaMericiVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 29 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -59,7 +59,7 @@ let dates = year => {
     },
     {
       "key": "saintCasimir",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 2, day: 4 }),
       "data": {
         "meta": {
@@ -70,7 +70,7 @@ let dates = year => {
     // jarosz: Moved saintAdalbert outside holy week and octave of Easter
     {
       "key": "saintAdalbertBishopAndMartyr",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": ( y => {
 
         _holyWeek = Dates.holyWeek( y );
@@ -109,7 +109,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -123,7 +123,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyQueenOfPoland",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 4, day: 3 }),
       "data": {
         "meta": {
@@ -133,7 +133,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyHelpOfChristians",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 24 }),
       "data": {
         "meta": {
@@ -143,7 +143,7 @@ let dates = year => {
     },
     {
       "key": "saintFlorianMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 4 }),
       "data": {
         "meta": {
@@ -153,13 +153,13 @@ let dates = year => {
     },
     {
       "key": "saintStanislausKazimierczykPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 5 }),
       "data": {}
     },
     {
       "key": "saintsPhilipAndJamesApostles",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 6 }),
       "data": {
         "meta": {
@@ -169,7 +169,7 @@ let dates = year => {
     },
     {
       "key": "saintStanislausBishopAndMartyr",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 4, day: 8 }),
       "data": {
         "meta": {
@@ -179,7 +179,7 @@ let dates = year => {
     },
     {
       "key": "saintAndrewBobolaPriestAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {
         "meta": {
@@ -189,7 +189,7 @@ let dates = year => {
     },
     {
       "key": "saintUrsulaLedochowskaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 29 }),
       "data": {
         "meta": {
@@ -199,13 +199,13 @@ let dates = year => {
     },
     {
       "key": "saintJohnSarkanderPriestAndMartyrSaintZdzislawa",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 30 }),
       "data": {}
     },
     {
       "key": "saintHedwigOfPoland",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 8 }),
       "data": {
         "meta": {
@@ -215,7 +215,7 @@ let dates = year => {
     },
     {
       "key": "blessedBogumilBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 10 }),
       "data": {
         "meta": {
@@ -225,13 +225,13 @@ let dates = year => {
     },
     {
       "key": "blessedAntoniNowowiejskiBishopAndCompanionsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 12 }),
       "data": {}
     },
     {
       "key": "blessedMichaelKozalBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 14 }),
       "data": {
         "meta": {
@@ -241,7 +241,7 @@ let dates = year => {
     },
     {
       "key": "blessedJolantaReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 15 }),
       "data": {
         "meta": {
@@ -251,7 +251,7 @@ let dates = year => {
     },
     {
       "key": "saintAlbertChmielowskiReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 17 }),
       "data": {
         "meta": {
@@ -261,19 +261,19 @@ let dates = year => {
     },
     {
       "key": "saintZygmuntGorazdowskiPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 26 }),
       "data": {}
     },
     {
       "key": "saintOttoOfBambergBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 1 }),
       "data": {}
     },
     {
       "key": "saintMariaGorettiVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 5 }),
       "data": {
         "meta": {
@@ -286,7 +286,7 @@ let dates = year => {
     },
     {
       "key": "blessedMariaTeresaLedochowskaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 6 }),
       "data": {
         "meta": {
@@ -296,7 +296,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnOfDuklaPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 8 }),
       "data": {
         "meta": {
@@ -306,7 +306,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -316,7 +316,7 @@ let dates = year => {
     },
     {
       "key": "saintBrunoBonifaceOfQuerfurtBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 12 }),
       "data": {
         "meta": {
@@ -326,7 +326,7 @@ let dates = year => {
     },
     {
       "key": "saintsAndrewZorardAndBenedictHermits",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 13 }),
       "data": {
         "meta": {
@@ -336,7 +336,7 @@ let dates = year => {
     },
     {
       "key": "saintHenryBishopAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 14 }),
       "data": {
         "meta": {
@@ -349,7 +349,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfMountCarmel",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 16 }),
       "data": {
         "meta": {
@@ -359,13 +359,13 @@ let dates = year => {
     },
     {
       "key": "saintSimonOfLipnicaPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 18 }),
       "data": {}
     },
     {
       "key": "blessedCzeslawPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 20 }),
       "data": {
         "meta": {
@@ -375,13 +375,13 @@ let dates = year => {
     },
     {
       "key": "saintApollinaris",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 21 }),
       "data": {}
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -391,7 +391,7 @@ let dates = year => {
     },
     {
       "key": "saintKingaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 24 }),
       "data": {
         "meta": {
@@ -401,19 +401,19 @@ let dates = year => {
     },
     {
       "key": "saintCharbelMakhloufPriestAndHermit",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 28 }),
       "data": {}
     },
     {
       "key": "blessedEdmundBojanowski",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 7 }),
       "data": {}
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -427,7 +427,7 @@ let dates = year => {
     },
     {
       "key": "saintHyacinthPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 17 }),
       "data": {
         "meta": {
@@ -437,7 +437,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfCzestochowa",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 7, day: 26 }),
       "data": {
         "meta": {
@@ -447,7 +447,7 @@ let dates = year => {
     },
     {
       "key": "blessedBronislawaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 1 }),
       "data": {
         "meta": {
@@ -457,13 +457,13 @@ let dates = year => {
     },
     {
       "key": "blessedMariaStellaAndCompanionsVirginsAndMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 4 }),
       "data": {}
     },
     {
       "key": "saintMelchiorGrodzieckiPriestAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 7 }),
       "data": {
         "meta": {
@@ -473,25 +473,25 @@ let dates = year => {
     },
     {
       "key": "blessedAnielaSalawaVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 9 }),
       "data": {}
     },
     {
       "key": "saintDenisAndCompanionsMartyrsSaintJohnLeonardiPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 10 }),
       "data": {}
     },
     {
       "key": "saintZygmuntSzczesnyFelinskiBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 17 }),
       "data": {}
     },
     {
       "key": "saintStanislausKostkaReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 8, day: 18 }),
       "data": {
         "meta": {
@@ -501,20 +501,20 @@ let dates = year => {
     },
     {
       "key": "blessedWladyslawOfGielniowPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 25 }),
       "data": {}
     },
     // jarosz: Split saintRuizAndCo and saintWenceslaus (they are a single celebration in general.js)
     {
       "key": "saintsLawrenceRuizAndCompanionsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 26 }),
       "data": {}
     },
     {
       "key": "saintWenceslausMartyr",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 8, day: 28 }),
       "data": {
         "meta": {
@@ -524,7 +524,7 @@ let dates = year => {
     },
     {
       "key": "saintFaustinaKowalskaVirginAndReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 5 }),
       "data": {
         "meta": {
@@ -534,7 +534,7 @@ let dates = year => {
     },
     {
       "key": "blessedVincentKadlubekBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 9 }),
       "data": {
         "meta": {
@@ -544,13 +544,13 @@ let dates = year => {
     },
     {
       "key": "blessedMaryAngelaTruszkowskaVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 10 }),
       "data": {}
     },
     {
       "key": "blessedJohnBeyzymPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 12 }),
       "data": {
         "meta": {
@@ -560,26 +560,26 @@ let dates = year => {
     },
     {
       "key": "blessedHonoratKozminskiPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 13 }),
       "data": {}
     },
     // jarosz: Split saintHedwig and saintMargaretMaryAlacoque and rename saintHedwig to saintHedwigOfSilesia, to make it less ambiguous
     {
       "key": "saintMargaretMaryAlacoque",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 14 }),
       "data": {}
     },
     {
       "key": "saintHedwigOfSilesia",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 16 }),
       "data": {}
     },
     {
       "key": "saintJohnOfKantyPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 20 }),
       "data": {
         "meta": {
@@ -589,7 +589,7 @@ let dates = year => {
     },
     {
       "key": "blessedJakubStrzemieBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 21 }),
       "data": {
         "meta": {
@@ -599,7 +599,7 @@ let dates = year => {
     },
     {
       "key": "popeSaintJohnPaulII",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 22 }),
       "data": {
         "meta": {
@@ -609,14 +609,14 @@ let dates = year => {
     },
     {
       "key": "saintJosefBilczewskiBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 23 }),
       "data": {}
     },
     // jarosz: Created Dedication of a particular church: solemnity on last Sunday of October
     {
       "key": "dedicationOfAParticularChurch",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment({ year: 2015, month: 9 }).endOf('month').startOf('week'),
       "data": {
         "meta": {
@@ -626,7 +626,7 @@ let dates = year => {
     },
     {
       "key": "saintsBenedyktJanMateuszIsaakAndKrystynMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 13 }),
       "data": {
         "meta": {
@@ -636,7 +636,7 @@ let dates = year => {
     },
     {
       "key": "blessedKarolinaKozkownaVirginAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 18 }),
       "data": {
         "meta": {
@@ -646,7 +646,7 @@ let dates = year => {
     },
     {
       "key": "blessedSalomeVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 19 }),
       "data": {
         "meta": {
@@ -656,7 +656,7 @@ let dates = year => {
     },
     {
       "key": "saintRafalKalinowskiPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 20 }),
       "data": {
         "meta": {
@@ -666,26 +666,26 @@ let dates = year => {
     },
     {
       "key": "blessedMaryOfJesusTheGoodShepherdVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 25 }),
       "data": {}
     },
     {
       "key": "blessedRafalChylinskiPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 2 }),
       "data": {}
     },
     {
       "key": "saintBarbaraVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 4 }),
       "data": {}
     },
     // [pejulian] Needs confirmation: In Poland this day is a feast
     {
       "key": "maryMotherOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 1, 'days'))( year ),
       "data": {
         "prioritized": true,
@@ -696,7 +696,7 @@ let dates = year => {
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/portugal.js
+++ b/src/calendars/portugal.js
@@ -9,13 +9,13 @@ let dates = year => {
   let _dates = [
     {
       "key": "blessedGoncaloDeAmarantePriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 11 }),
       "data": {}
     },
     {
       "key": "saintJohnDeBritoPriestAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 4 }),
       "data": {
         "meta": {
@@ -28,7 +28,7 @@ let dates = year => {
     },
     {
       "key": "theFiveWoundsOfTheLord",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 7 }),
       "data": {
         "meta": {
@@ -38,7 +38,7 @@ let dates = year => {
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -49,7 +49,7 @@ let dates = year => {
     },
     {
       "key": "saintTheotoniusPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 18 }),
       "data": {
         "meta": {
@@ -59,13 +59,13 @@ let dates = year => {
     },
     {
       "key": "blessedJacintaAndFranciscoMarto",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 20 }),
       "data": {}
     },
     {
       "key": "saintJohnOfGodPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 8 }),
       "data": {
         "meta": {
@@ -75,7 +75,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -89,13 +89,13 @@ let dates = year => {
     },
     {
       "key": "blessedJoanOfPortugalVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 12 }),
       "data": {}
     },
     {
       "key": "ourLadyOfFatima",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 4, day: 13 }),
       "data": {
         "meta": {
@@ -105,7 +105,7 @@ let dates = year => {
     },
     {
       "key": "guardianAngelOfPortugal",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 10 }),
       "data": {
         "meta": {
@@ -115,7 +115,7 @@ let dates = year => {
     },
     {
       "key": "saintAnthonyOfLisbonPriestAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 5, day: 13 }),
       "data": {
         "meta": {
@@ -128,13 +128,13 @@ let dates = year => {
     },
     {
       "key": "blessedSanchaAndMafaldaVirginsOrBlessedTheresaOfPOrtugalReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 20 }),
       "data": {}
     },
     {
       "key": "saintElizabethOfPortugal",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 4 }),
       "data": {
         "meta": {
@@ -144,7 +144,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -155,7 +155,7 @@ let dates = year => {
     },
     {
       "key": "blessedInacioDeAzevedoPriestAndCompanionsMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 17 }),
       "data": {
         "meta": {
@@ -165,7 +165,7 @@ let dates = year => {
     },
     {
       "key": "blessedBartholomewOfTheMartyrsBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 18 }),
       "data": {
         "meta": {
@@ -175,7 +175,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -186,7 +186,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -200,7 +200,7 @@ let dates = year => {
     },
     {
       "key": "saintBeatriceOfSilvaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 1 }),
       "data": {
         "meta": {
@@ -210,19 +210,19 @@ let dates = year => {
     },
     {
       "key": "saintDenisAndCompanionsMartyrsSaintJohnLeonardiPriestBlessedJohnNewmanBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 9 }),
       "data": {}
     },
     {
       "key": "blessedGoncaloDeLagosPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 27 }),
       "data": {}
     },
     {
       "key": "saintNunoDeSantaMaria",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 6 }),
       "data": {
         "meta": {
@@ -232,7 +232,7 @@ let dates = year => {
     },
     {
       "key": "saintFructuosusSaintMartinOfDumeAndSaintGeraldBishops",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 5 }),
       "data": {
         "meta": {

--- a/src/calendars/puertoRico.js
+++ b/src/calendars/puertoRico.js
@@ -9,25 +9,25 @@ let dates = year => {
   let _dates = [
     {
       "key": "mostHolyNameOfJesusOrOurLadyOfBethlehem",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 3 }),
       "data": {}
     },
     {
       "key": "blessedMariaDoloresRodriguezSopenaVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 10 }),
       "data": {}
     },
     {
       "key": "blessedCarlosManuelRodriguez",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 4 }),
       "data": {}
     },
     {
       "key": "ourLadyOfMountCarmel",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 16 }),
       "data": {
         "meta": {
@@ -37,13 +37,13 @@ let dates = year => {
     },
     {
       "key": "saintTeresaOfJesusJornetEIbarsVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 26 }),
       "data": {}
     },
     {
       "key": "saintRoseOfLima",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 30 }),
       "data": {
         "meta": {
@@ -53,7 +53,7 @@ let dates = year => {
     },
     {
       "key": "blessedsCarlosSpinolaAndJeronimoDeAngelisPriestsAndMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 10 }),
       "data": {
         "meta": {
@@ -65,13 +65,13 @@ let dates = year => {
     },
     {
       "key": "saintSoledadTorresAcostaVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 11 }),
       "data": {}
     },
     {
       "key": "ourLadyMotherOfDivineProvidencePatronessOfPuertoRico",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 10, day: 19 }),
       "data": {
         "meta": {
@@ -81,7 +81,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfGuadalupe",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {
         "meta": {
@@ -91,7 +91,7 @@ let dates = year => {
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/romania.js
+++ b/src/calendars/romania.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -20,7 +20,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnCassianPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 28 }),
       "data": {
         "meta": {
@@ -30,7 +30,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -44,7 +44,7 @@ let dates = year => {
     },
     {
       "key": "blessedVladimirGhikaPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {
         "meta": {
@@ -56,7 +56,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -67,7 +67,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -78,7 +78,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {

--- a/src/calendars/russia.js
+++ b/src/calendars/russia.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "blessedGeorgeMatulewiczBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 27 }),
       "data": {
         "meta": {
@@ -19,13 +19,13 @@ let dates = year => {
     },
     {
       "key": "blessedBoleslawaMariaLamentVirginAndSaintAngelaMericiVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 29 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -36,7 +36,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -50,7 +50,7 @@ let dates = year => {
     },
     {
       "key": "saintGeorgeMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 6 }),
       "data": {
         "meta": {
@@ -63,7 +63,7 @@ let dates = year => {
     },
     {
       "key": "saintTheodosiusOfTheCavesAbbot",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {
         "meta": {
@@ -73,13 +73,13 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfPerpetualHelpOrBlessedLeonidFeodorovPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 27 }),
       "data": {}
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -90,7 +90,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -101,19 +101,19 @@ let dates = year => {
     },
     {
       "key": "saintAnthonyOfTheCavesMonk",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 24 }),
       "data": {}
     },
     {
       "key": "saintOlga",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 24 }),
       "data": {}
     },
     {
       "key": "saintVladimirTheGreat",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 28 }),
       "data": {
         "meta": {
@@ -123,7 +123,7 @@ let dates = year => {
     },
     {
       "key": "saintsBorisAndGlebMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 5 }),
       "data": {
         "meta": {
@@ -135,7 +135,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -149,19 +149,19 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfCzestochowa",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 26 }),
       "data": {}
     },
     {
       "key": "ourLadyOfVladimir",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 7 }),
       "data": {}
     },
     {
       "key": "saintFaustinaKowalskaVirginAndReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 5 }),
       "data": {
         "meta": {
@@ -171,7 +171,7 @@ let dates = year => {
     },
     {
       "key": "blessedOleksiyZarytskyiPriestAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 30 }),
       "data": {
         "meta": {
@@ -181,13 +181,13 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfTheGateOfDawn",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 16 }),
       "data": {}
     },
     {
       "key": "saintRafalKalinowskiPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 20 }),
       "data": {
         "meta": {
@@ -197,7 +197,7 @@ let dates = year => {
     },
     {
       "key": "saintAndrewTheApostlePatronOfRussia",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 10, day: 30 }),
       "data": {
         "meta": {
@@ -207,7 +207,7 @@ let dates = year => {
     },
     {
       "key": "saintBarbaraVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 4 }),
       "data": {
         "meta": {
@@ -219,7 +219,7 @@ let dates = year => {
     },
     {
       "key": "saintNicholasBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 6 }),
       "data": {
         "meta": {

--- a/src/calendars/scotland.js
+++ b/src/calendars/scotland.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintKentigern",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 13 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -30,7 +30,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnOgilvie",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 2, day: 10 }),
       "data": {
         "meta": {
@@ -40,7 +40,7 @@ let dates = year => {
     },
     {
       "key": "saintPatrickBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 2, day: 17 }),
       "data": {
         "meta": {
@@ -50,7 +50,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -64,7 +64,7 @@ let dates = year => {
     },
     {
       "key": "saintColumba",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 9 }),
       "data": {
         "meta": {
@@ -74,7 +74,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -85,7 +85,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -96,7 +96,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -110,7 +110,7 @@ let dates = year => {
     },
     {
       "key": "saintNinian",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 16 }),
       "data": {
         "meta": {
@@ -120,7 +120,7 @@ let dates = year => {
     },
     {
       "key": "saintMargaretOfScotland",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 16 }),
       "data": {
         "meta": {
@@ -130,7 +130,7 @@ let dates = year => {
     },
     {
       "key": "saintAndrewTheApostle",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 10, day: 30 }),
       "data": {
         "meta": {

--- a/src/calendars/slovakia.js
+++ b/src/calendars/slovakia.js
@@ -10,7 +10,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
   let _dates = [
     {
       "key": "saintAdalbertBishopAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 23 }),
       "data": {
         "meta": {
@@ -23,7 +23,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintGeorgeMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 24 }),
       "data": {
         "meta": {
@@ -35,7 +35,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -49,7 +49,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintFlorianMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 4 }),
       "data": {
         "meta": {
@@ -59,7 +59,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "blessedSaraSalkahaziVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 11 }),
       "data": {
         "meta": {
@@ -71,7 +71,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintJohnNepomucenePriestAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {
         "meta": {
@@ -84,13 +84,13 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintLadislaus",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 27 }),
       "data": {}
     },
     {
       "key": "visitationOfTheBlessedVirginMary",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 2 }),
       "data": {
         "meta": {
@@ -103,7 +103,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     // https://en.wikipedia.org/wiki/Saints_Cyril_and_Methodius
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ((y, flag) => {
         return flag ? moment.utc({ year: year, month: 1, day: 14 }): moment.utc({ year: year, month: 6, day: 5 });
       })(year, saintsCyrilMonkAndMethodiusBishopOnFeb14),
@@ -116,7 +116,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {
@@ -126,13 +126,13 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintAnthonyZaccariaPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 7 }),
       "data": {}
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -143,7 +143,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintsAndrewZoerardusAndBenedictHermits",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 17 }),
       "data": {
         "meta": {
@@ -153,7 +153,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -164,7 +164,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintGorazdAndCompanions",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 27 }),
       "data": {
         "meta": {
@@ -174,7 +174,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "blessedZdenkaSchelingovaVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 30 }),
       "data": {
         "meta": {
@@ -186,7 +186,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -200,7 +200,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintHelena",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 18 }),
       "data": {
         "meta": {
@@ -210,7 +210,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintTeresaOfCalcuttaReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 5 }),
       "data": {
         "meta": {
@@ -220,7 +220,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintsMarkoKrizinMelicharGrodeckiAndStephenPongracPriestsAndMartyrs",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 7 }),
       "data": {
         "meta": {
@@ -233,7 +233,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "ourLadyOfSorrows",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 8, day: 15 }),
       "data": {
         "meta": {
@@ -243,7 +243,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintFaustinaKowalskaVirginAndReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 5 }),
       "data": {
         "meta": {
@@ -253,13 +253,13 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintGallAbbotAndMissionary",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 16 }),
       "data": {}
     },
     {
       "key": "saintMaurusBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 25 }),
       "data": {
         "meta": {
@@ -269,7 +269,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "dedicationOfAParticularChurch",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 9, day: 26 }),
       "data": {
         "meta": {
@@ -279,7 +279,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "allSouls",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 2 }),
       "data": {
         "meta": {
@@ -289,8 +289,14 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintEmeric",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 5 }),
+      "data": {}
+    },
+    {
+      "key": "ourLordJesusChristTheEternalHighPriest",
+      "type": Types.FEAST,
+      "moment": moment.utc({ year: year, month: 5, day: 16 }),
       "data": {
         "meta": {
           "liturgicalColor": LiturgicalColors.WHITE
@@ -303,7 +309,7 @@ let dates = (year, saintsCyrilMonkAndMethodiusBishopOnFeb14 = false ) => {
     },
     {
       "key": "saintJohnDamascenePriestAndDoctorOrSaintBarbaraVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 4 }),
       "data": {
         "meta": {

--- a/src/calendars/slovenia.js
+++ b/src/calendars/slovenia.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {

--- a/src/calendars/spain.js
+++ b/src/calendars/spain.js
@@ -9,13 +9,13 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintEulogiusOfCordobaBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 9 }),
       "data": {}
     },
     {
       "key": "saintsFructuosusBishopAndAuguriusAndEulogiusDeaconsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 20 }),
       "data": {
         "meta": {
@@ -27,7 +27,7 @@ let dates = year => {
     },
     {
       "key": "saintVincentDeaconAndMartyr",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 22 }),
       "data": {
         "meta": {
@@ -40,13 +40,13 @@ let dates = year => {
     },
     {
       "key": "saintIldephonsusOfToledoBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 23 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -57,7 +57,7 @@ let dates = year => {
     },
     {
       "key": "saintHermenegildMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 13 }),
       "data": {
         "meta": {
@@ -67,7 +67,7 @@ let dates = year => {
     },
     {
       "key": "saintIsidoreOfSevilleBishopAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 26 }),
       "data": {
         "meta": {
@@ -80,7 +80,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -94,7 +94,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnOfAvilaPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 10 }),
       "data": {
         "meta": {
@@ -104,7 +104,7 @@ let dates = year => {
     },
     {
       "key": "saintIsidoreTheFarmer",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 15 }),
       "data": {
         "meta": {
@@ -114,31 +114,31 @@ let dates = year => {
     },
     {
       "key": "saintPaschalBaylon",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 17 }),
       "data": {}
     },
     {
       "key": "saintJoaquinaVedruna",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 22 }),
       "data": {}
     },
     {
       "key": "saintFerdinand",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 30 }),
       "data": {}
     },
     {
       "key": "saintMariaMicaelaOfTheBlessedSacramentVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 15 }),
       "data": {}
     },
     {
       "key": "saintPelagiusMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 26 }),
       "data": {
         "meta": {
@@ -150,7 +150,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -161,7 +161,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfMountCarmel",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 16 }),
       "data": {
         "meta": {
@@ -171,7 +171,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -182,13 +182,13 @@ let dates = year => {
     },
     {
       "key": "saintJamesApostlePatronOfSpain",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 6, day: 25 }),
       "data": {}
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -202,13 +202,13 @@ let dates = year => {
     },
     {
       "key": "saintEzequielMorenoBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 19 }),
       "data": {}
     },
     {
       "key": "saintTeresaOfJesusJornetEIbarsVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 26 }),
       "data": {
         "meta": {
@@ -218,25 +218,25 @@ let dates = year => {
     },
     {
       "key": "saintFrancisBorgiaPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 3 }),
       "data": {}
     },
     {
       "key": "saintThomasOfVillanovaBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 10 }),
       "data": {}
     },
     {
       "key": "saintSoledadTorresAcostaVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 11 }),
       "data": {}
     },
     {
       "key": "ourLadyOfThePillar",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 9, day: 12 }),
       "data": {
         "meta": {
@@ -246,7 +246,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaOfJesusVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 9, day: 15 }),
       "data": {
         "meta": {
@@ -259,25 +259,25 @@ let dates = year => {
     },
     {
       "key": "saintPeterOfAlcantaraPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 19 }),
       "data": {}
     },
     {
       "key": "saintLeanderBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 13 }),
       "data": {}
     },
     {
       "key": "saintEulaliaOfMeridaVirginAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 10 }),
       "data": {}
     },
     {
       "key": "saintJohnOfTheCrossDoctorOfTheChurch",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 14 }),
       "data": {
         "meta": {
@@ -290,7 +290,7 @@ let dates = year => {
     },
     {
       "key": "jesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 5, day: 16 }),
       "data": {
         "meta": {
@@ -300,7 +300,7 @@ let dates = year => {
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/sriLanka.js
+++ b/src/calendars/sriLanka.js
@@ -5,17 +5,17 @@ import { Dates, Utils } from '../lib';
 import { Titles, Types, LiturgicalColors } from '../constants';
 
 let dates = year => {
-  
+
   let _dates = [
     {
       "key": "blessedJosephVazPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 16 }),
       "data": {}
     },
     {
       "key": "ourLadyOfLanka",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 4 }),
       "data": {
         "meta": {
@@ -25,7 +25,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfMadhu",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 2 }),
       "data": {
         "meta": {
@@ -40,5 +40,5 @@ let dates = year => {
 };
 
 export {
-  dates 
+  dates
 };

--- a/src/calendars/sweden.js
+++ b/src/calendars/sweden.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/switzerland.js
+++ b/src/calendars/switzerland.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {

--- a/src/calendars/ukraine.js
+++ b/src/calendars/ukraine.js
@@ -9,19 +9,19 @@ let dates = year => {
   let _dates = [
     {
       "key": "blessedMarcelinaDarowskaReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 5 }),
       "data": {}
     },
     {
       "key": "blessedBronislawMarkiewiczPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 30 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -33,7 +33,7 @@ let dates = year => {
     // [pejulian] Needs confirmation: In Ukraine this day is a feast
     {
       "key": "maryMotherOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 1, 'days'))( year ),
       "data": {
         "priorized": true,
@@ -44,7 +44,7 @@ let dates = year => {
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -58,7 +58,7 @@ let dates = year => {
     },
     {
       "key": "saintAndrewBobolaPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 16 }),
       "data": {
         "meta": {
@@ -70,7 +70,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnNepomucenePriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 21 }),
       "data": {
         "meta": {
@@ -82,37 +82,37 @@ let dates = year => {
     },
     {
       "key": "saintAlbertChmielowskiReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 17 }),
       "data": {}
     },
     {
       "key": "saintZygmuntGorazdowskiPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 26 }),
       "data": {}
     },
     {
       "key": "saintJohnOfDuklaPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 8 }),
       "data": {}
     },
     {
       "key": "saintHedwigOfPoland",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 18 }),
       "data": {}
     },
     {
       "key": "saintOlga",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 24 }),
       "data": {}
     },
     {
       "key": "saintVladimirTheGreat",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 28 }),
       "data": {
         "meta": {
@@ -122,7 +122,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -133,7 +133,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -144,7 +144,7 @@ let dates = year => {
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -158,13 +158,13 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfCzestochowa",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 26 }),
       "data": {}
     },
     {
       "key": "blessedWladyslawBladzinskiPriestAndCompanionsMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 9 }),
       "data": {
         "meta": {
@@ -177,7 +177,7 @@ let dates = year => {
     },
     {
       "key": "saintStanislausKostkaReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 18 }),
       "data": {
         "meta": {
@@ -187,7 +187,7 @@ let dates = year => {
     },
     {
       "key": "saintJozefBilczewskiBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 23 }),
       "data": {}
     },

--- a/src/calendars/unitedStates.js
+++ b/src/calendars/unitedStates.js
@@ -10,7 +10,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintElizabethAnnSetonReligious",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 4 }),
       "data": {
         "meta": {
@@ -20,7 +20,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnNeumannBishop",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 5 }),
       "data": {
         "meta": {
@@ -30,13 +30,13 @@ let dates = year => {
     },
     {
       "key": "saintAndreBessetteReligious",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 6 }),
       "data": {}
     },
     {
       "key": "saintVincentDeaconAndMartyrOrSaintMarianneCopeVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 0, day: 22 }),
       "data": {
         "meta": {
@@ -48,31 +48,31 @@ let dates = year => {
     },
     {
       "key": "saintKatharineDrexelVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 2, day: 3 }),
       "data": {}
     },
     {
       "key": "saintDamienDeVeusterPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 10 }),
       "data": {}
     },
     {
       "key": "saintIsidoreTheFarmer",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 15 }),
       "data": {}
     },
     {
       "key": "blessedJuniperoSerraPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 1 }),
       "data": {}
     },
     {
       "key": "saintKateriTekakwithaVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 14 }),
       "data": {
         "meta": {
@@ -82,13 +82,13 @@ let dates = year => {
     },
     {
       "key": "saintCamillusDeLellisPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 18 }),
       "data": {}
     },
     {
       "key": "saintPeterClaverPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 9 }),
       "data": {
         "meta": {
@@ -98,13 +98,13 @@ let dates = year => {
     },
     {
       "key": "blessedMarieRoseDurocherVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 6 }),
       "data": {}
     },
     {
       "key": "saintsJeanDeBrebeufAndIsaacJoguesPriestsAndCompanionsMartyrsSaintPaulOfTheCrossPriest",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 19 }),
       "data": {
         "meta": {
@@ -117,13 +117,13 @@ let dates = year => {
     },
     {
       "key": "saintPaulOfTheCrossPriest",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 20 }),
       "data": {}
     },
     {
       "key": "saintFrancesXavierCabriniVirgin",
-      "type": Types[5],
+      "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 13 }),
       "data": {
         "meta": {
@@ -133,13 +133,13 @@ let dates = year => {
     },
     {
       "key": "saintRosePhilippineDuchesneVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 18 }),
       "data": {}
     },
     {
       "key": "blessedMiguelAgustinProPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 23 }),
       "data": {
         "meta": {
@@ -151,7 +151,7 @@ let dates = year => {
     },
     {
       "key": "ourLadyOfGuadalupe",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 11, day: 12 }),
       "data": {
         "meta": {

--- a/src/calendars/uruguay.js
+++ b/src/calendars/uruguay.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/venezuela.js
+++ b/src/calendars/venezuela.js
@@ -9,7 +9,7 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -19,7 +19,7 @@ let dates = year => {
     },
     {
       "key": "ourLordJesusChristTheEternalHighPriest",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => Dates.pentecostSunday( y ).add( 4, 'days' ))(year),
       "data": {
         "meta": {

--- a/src/calendars/vietnam.js
+++ b/src/calendars/vietnam.js
@@ -6,11 +6,11 @@ import { Dates, Utils } from '../lib';
 import { Titles, Types, LiturgicalColors } from '../constants';
 
 let dates = year => {
-  
+
   let _dates = [
     {
       "key": "vietnameseMartyrs",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 13 }),
       "data": {
         "meta": {
@@ -28,5 +28,5 @@ let dates = year => {
 };
 
 export {
-  dates 
+  dates
 };

--- a/src/calendars/wales.js
+++ b/src/calendars/wales.js
@@ -10,13 +10,13 @@ let dates = year => {
   let _dates = [
     {
       "key": "saintTeiloBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 1, day: 9 }),
       "data": {}
     },
     {
       "key": "saintsCyrilMonkAndMethodiusBishop",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 1, day: 14 }),
       "data": {
         "meta": {
@@ -27,7 +27,7 @@ let dates = year => {
     },
     {
       "key": "saintDavidBishop",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": moment.utc({ year: year, month: 2, day: 1 }),
       "data": {
         "meta": {
@@ -37,13 +37,13 @@ let dates = year => {
     },
     {
       "key": "saintBeunoAbbot",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 3, day: 20 }),
       "data": {}
     },
     {
       "key": "saintCatherineOfSienaVirginAndDoctorOfTheChurch",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 3, day: 29 }),
       "data": {
         "meta": {
@@ -57,13 +57,13 @@ let dates = year => {
     },
     {
       "key": "saintAsaphBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 4, day: 5 }),
       "data": {}
     },
     {
       "key": "saintsAlbanJuliusAndAaronMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 5, day: 20 }),
       "data": {
         "meta": {
@@ -76,7 +76,7 @@ let dates = year => {
     },
     {
       "key": "saintBenedictOfNursiaAbbot",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 11 }),
       "data": {
         "meta": {
@@ -87,7 +87,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnJonesPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 12 }),
       "data": {
         "meta": {
@@ -100,7 +100,7 @@ let dates = year => {
     },
     {
       "key": "saintBridgetOfSwedenReligious",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 6, day: 23 }),
       "data": {
         "meta": {
@@ -111,7 +111,7 @@ let dates = year => {
     },
     {
       "key": "saintsPhilipEvansAndJohnLloydPriestsAndMartyrs",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 25 }),
       "data": {
         "meta": {
@@ -124,13 +124,13 @@ let dates = year => {
     },
     {
       "key": "saintGermanusOfAuxerreBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 3 }),
       "data": {}
     },
     {
       "key": "saintTeresaBenedictaOfTheCrossEdithSteinVirginAndMartyr",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 7, day: 9 }),
       "data": {
         "meta": {
@@ -144,7 +144,7 @@ let dates = year => {
     },
     {
       "key": "saintDavidLewisPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 7, day: 26 }),
       "data": {
         "meta": {
@@ -157,13 +157,13 @@ let dates = year => {
     },
     {
       "key": "saintDeiniolBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 8, day: 11 }),
       "data": {}
     },
     {
       "key": "saintRichardGwynMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 9, day: 16 }),
       "data": {
         "meta": {
@@ -176,7 +176,7 @@ let dates = year => {
     },
     {
       "key": "theSixWelshMartyrsAndCompanions",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 9, day: 25 }),
       "data": {
         "meta": {
@@ -189,13 +189,13 @@ let dates = year => {
     },
     {
       "key": "saintWinefrideVirgin",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 3 }),
       "data": {}
     },
     {
       "key": "saintIlltudAbbot",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 6 }),
       "data": {}
     },
@@ -206,7 +206,7 @@ let dates = year => {
     // on a Sunday it replaces the Sunday.
     {
       "key": "allSaints",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": ( y => {
         let date = moment.utc({ year: y, month: 10, day: 1 });
         if ( _.eq(date.day(), 6 )) {
@@ -225,7 +225,7 @@ let dates = year => {
     },
     {
       "key": "allSouls",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": ( y => {
         let date = moment.utc({ year: y, month: 10, day: 1 });
         if ( _.eq( date.day(), 6 ) ) { // If All Saints is on Saturday
@@ -245,7 +245,7 @@ let dates = year => {
     },
     {
       "key": "allSaintsOfWales",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 6 }),
       "data": {
         "prioritized": true,
@@ -256,7 +256,7 @@ let dates = year => {
     },
     {
       "key": "saintDubriciusBishop",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 10, day: 14 }),
       "data": {
         "meta": {
@@ -268,7 +268,7 @@ let dates = year => {
     },
     {
       "key": "saintJohnRobertsPriestAndMartyr",
-      "type": Types[6],
+      "type": Types.OPT_MEMORIAL,
       "moment": moment.utc({ year: year, month: 11, day: 10 }),
       "data": {
         "meta": {
@@ -284,7 +284,7 @@ let dates = year => {
     // Replaces 20th Sunday in Ordinary Time when it falls on a Sunday.
     {
       "key": "peterAndPaulApostles",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": ( y => {
         let date = moment.utc({ year: y, month: 5, day: 29 });
         if ( _.eq(date.day(), 1 )) {
@@ -309,7 +309,7 @@ let dates = year => {
     // Replaces 20th Sunday in Ordinary Time when it falls on a Sunday.
     {
       "key": "assumption",
-      "type": Types[0],
+      "type": Types.SOLEMNITY,
       "moment": ( y => {
         let date = moment.utc({ year: y, month: 7, day: 15 });
         if ( _.eq(date.day(), 1 )) {

--- a/src/constants/Types.js
+++ b/src/constants/Types.js
@@ -1,12 +1,81 @@
-const Types = [
-  "SOLEMNITY",          // [0]
-  "SUNDAY",             // [1]
-  "TRIDUUM",            // [2]
-  "HOLY_WEEK",          // [3]
-  "FEAST",              // [4]
-  "MEMORIAL",           // [5]
-  "OPT_MEMORIAL",       // [6]
-  "COMMEMORATION",      // [7]
-  "FERIA"               // [8]
-];
-export default Types;
+/**
+ * Extend Array to provide the rank types as properties (syntactic sugar)
+ * Types[0] == Types.SOLEMNITY and so on
+ * @extends Array
+ */
+class Types extends Array {
+  constructor(...items) {
+    // Initialize Array
+    super(...items);
+
+    // Iterate over all types and create dynamic read-only properties
+    for (let key of this) {
+      Object.defineProperty(this, key, {
+        value: key,
+        writable: false
+      });
+    }
+  }
+}
+
+// Rank types of celebrations.
+// Order is important:
+// Higher rank first, lower rank at the end.
+const TYPES = new Types(
+
+  /**
+   * @name Types#SOLEMNITY
+   * @type string
+   */
+  "SOLEMNITY",
+
+  /**
+   * @name Types#SUNDAY
+   * @type string
+   */
+  "SUNDAY",
+
+  /**
+   * @name Types#TRIDUUM
+   * @type string
+   */
+  "TRIDUUM",
+
+  /**
+   * @name Types#HOLY_WEEK
+   * @type string
+   */
+  "HOLY_WEEK",
+
+  /**
+   * @name Types#FEAST
+   * @type string
+   */
+  "FEAST",
+
+  /**
+   * @name Types#MEMORIAL
+   * @type string
+   */
+  "MEMORIAL",
+
+  /**
+   * @name Types#OPT_MEMORIAL
+   * @type string
+   */
+  "OPT_MEMORIAL",
+
+  /**
+   * @name Types#COMMEMORATION
+   * @type string
+   */
+  "COMMEMORATION",
+
+  /**
+   * @name Types#FERIA
+   * @type string
+   */
+  "FERIA"
+);
+
+export default TYPES;

--- a/src/lib/Calendar.js
+++ b/src/lib/Calendar.js
@@ -293,7 +293,7 @@ const _applyDates = ( options, dates ) => {
         // A SOLEMNITY will replace any date in the liturgical calendar
         // - solemnity must not override a solemnity in octave of EASTER
         //------------------------------------------------------------------
-        if (_.eq( candidate.type, _.head( Types ) ) && _.gt( _.indexOf( Types, date.type ), 0 )) {
+        if (_.eq( candidate.type, Types.SOLEMNITY ) && _.gt( _.indexOf( Types, date.type ), 0 )) {
           replace = true;
         }
 
@@ -302,9 +302,9 @@ const _applyDates = ( options, dates ) => {
         // in the SEASON OF LENT are reduced to a COMMEMORATION
         //------------------------------------------------------------------
         else if (
-          _.eq( date.type, _.last( Types ) )
+          _.eq( date.type, Types.FERIA )
           && _.eq( date.data.season.key, LiturgicalSeasons.LENT )
-          && ( _.eq( candidate.type, Types[5] ) || _.eq( candidate.type, Types[6] ) )
+          && ( _.eq( candidate.type, Types.MEMORIAL ) || _.eq( candidate.type, Types.OPT_MEMORIAL ) )
         ) {
           replace = true;
           derank = true;
@@ -315,9 +315,9 @@ const _applyDates = ( options, dates ) => {
         // outside LENT or the Easter Octave will replace the general FERIA
         //------------------------------------------------------------------
         else if (
-          _.eq( date.type, _.last( Types ) ) // If the current date is of type feria
+          _.eq( date.type, Types.FERIA ) // If the current date is of type feria
           && !_.eq( date.data.season.key, LiturgicalSeasons.LENT ) // And this feria is not in Lent
-          && ( _.eq( candidate.type, Types[5] ) || _.eq( candidate.type, Types[6] ) ) // And the candidate is either a memorial or optional memorial
+          && ( _.eq( candidate.type, Types.MEMORIAL ) || _.eq( candidate.type, Types.OPT_MEMORIAL ) ) // And the candidate is either a memorial or optional memorial
         ) {
           replace = true; // Then the candidate is fit to replace the feria
         }
@@ -327,8 +327,8 @@ const _applyDates = ( options, dates ) => {
         // - feria must not be in the octave of EASTER
         //------------------------------------------------------------------
         else if (
-          _.eq( candidate.type, Types[4] )
-          && _.eq( date.type, _.last( Types ) )
+          _.eq( candidate.type, Types.FEAST )
+          && _.eq( date.type, Types.FERIA )
           && !_.eq( date.data.season.key, LiturgicalSeasons.LENT )
           && !candidate.data.prioritized
         ) {
@@ -340,8 +340,8 @@ const _applyDates = ( options, dates ) => {
         // to a COMMEMORATION
         //------------------------------------------------------------------
         else if (
-          _.eq( candidate.type, Types[4] )
-          && _.eq( date.type, _.last( Types ) )
+          _.eq( candidate.type, Types.FEAST )
+          && _.eq( date.type, Types.FERIA )
           && _.eq( date.data.season.key, LiturgicalSeasons.LENT )
         ) {
           replace = true;
@@ -354,8 +354,8 @@ const _applyDates = ( options, dates ) => {
         // - feria must not be in the octave of EASTER
         //------------------------------------------------------------------
         else if (
-          _.eq( candidate.type, Types[4] )
-          && ( _.eq( date.type, _.last( Types ) ) || _.eq( date.type, Types[1] ) )
+          _.eq( candidate.type, Types.FEAST )
+          && ( _.eq( date.type, Types.FERIA ) || _.eq( date.type, Types.SUNDAY ) )
           && !_.eq( date.data.season.key, LiturgicalSeasons.LENT )
           && candidate.data.prioritized
         ) {
@@ -366,8 +366,8 @@ const _applyDates = ( options, dates ) => {
         // A Sunday can only replace a Sunday
         //------------------------------------------------------------------
         else if (
-          _.eq( date.type, Types[1] )
-          && _.eq( candidate.type, Types[1] )
+          _.eq( date.type, Types.SUNDAY )
+          && _.eq( candidate.type, Types.SUNDAY )
         ) {
           replace = true;
         }
@@ -378,8 +378,8 @@ const _applyDates = ( options, dates ) => {
         // except for SOLEMNITIES and certain FEASTS
         //------------------------------------------------------------------
         else if (
-          _.eq( date.type, _.last( Types ) )
-          && _.eq( candidate.type, _.last( Types ) )
+          _.eq( date.type, Types.FERIA )
+          && _.eq( candidate.type, Types.FERIA )
         ) {
           replace = true;
         }
@@ -395,7 +395,7 @@ const _applyDates = ( options, dates ) => {
         date.key = candidate.key;
         date.name = candidate.name;
         date.source = candidate.source;
-        date.type = ( derank ? Types[7] : candidate.type );
+        date.type = ( derank ? Types.COMMEMORATION : candidate.type );
         date.data = _.merge({}, date.data, candidate.data );
       }
     }

--- a/src/lib/Celebrations.js
+++ b/src/lib/Celebrations.js
@@ -17,7 +17,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     // Solemnities
     {
       "key": "immaculateConception",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.immaculateConception( year ),
       "data": {
         "prioritized": true,
@@ -28,7 +28,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "christmas",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.christmas( year ),
       "data": {
         "prioritized": true,
@@ -39,7 +39,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "maryMotherOfGod",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.maryMotherOfGod( year ),
       "data": {
         "prioritized": true,
@@ -50,7 +50,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "epiphany",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.epiphany( year, epiphanyOnJan6 ),
       "data": {
         "prioritized": true,
@@ -61,7 +61,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "trinitySunday",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.trinitySunday( year ),
       "data": {
         "prioritized": true,
@@ -72,7 +72,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "corpusChristi",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.corpusChristi( year, corpusChristiOnThursday ),
       "data": {
         "prioritized": true,
@@ -83,7 +83,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "sacredHeartOfJesus",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.sacredHeartOfJesus( year ),
       "data": {
         "prioritized": true,
@@ -94,7 +94,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "birthOfJohnTheBaptist",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.birthOfJohnTheBaptist( year ),
       "data": {
         "prioritized": true,
@@ -105,7 +105,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "peterAndPaulApostles",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.peterAndPaulApostles( year ),
       "data": {
         "prioritized": true,
@@ -116,7 +116,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "assumption",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.assumption( year ),
       "data": {
         "prioritized": true,
@@ -127,7 +127,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "allSaints",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.allSaints( year ),
       "data": {
         "prioritized": true,
@@ -138,7 +138,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "christTheKing",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.christTheKing( year ),
       "data": {
         "prioritized": true,
@@ -149,7 +149,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "josephHusbandOfMary",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.josephHusbandOfMary( year ),
       "data": {
         "prioritized": true,
@@ -160,7 +160,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "annunciation",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.annunciation( year ),
       "data": {
         "prioritized": true,
@@ -171,7 +171,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "easter",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.easter( year ),
       "data": {
         "prioritized": true,
@@ -182,7 +182,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "divineMercySunday",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.divineMercySunday( year ),
       "data": {
         "prioritized": true,
@@ -193,7 +193,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "ascension",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.ascension( year, ascensionOnSunday ),
       "data": {
         "prioritized": true,
@@ -204,7 +204,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "pentecostSunday",
-      "type": _.head( Types ),
+      "type": Types.SOLEMNITY,
       "moment": Dates.pentecostSunday( year ),
       "data": {
         "prioritized": true,
@@ -216,7 +216,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     // Lent, Holy Week & Triduum
     {
       "key": "ashWednesday",
-      "type": _.last( Types ),
+      "type": Types.FERIA,
       "moment": Dates.ashWednesday( year ),
       "data": {
         "prioritized": true,
@@ -233,7 +233,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "palmSunday",
-      "type": Types[1],
+      "type": Types.SUNDAY,
       "moment": Dates.palmSunday( year ),
       "data": {
         "prioritized": true,
@@ -250,7 +250,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "holyThursday",
-      "type": Types[2],
+      "type": Types.TRIDUUM,
       "moment": Dates.holyThursday( year ),
       "data": {
         "prioritized": true,
@@ -270,7 +270,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "goodFriday",
-      "type": Types[2],
+      "type": Types.TRIDUUM,
       "moment": Dates.goodFriday( year ),
       "data": {
         "prioritized": true,
@@ -290,7 +290,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "holySaturday",
-      "type": Types[2],
+      "type": Types.TRIDUUM,
       "moment": Dates.holySaturday( year ),
       "data": {
         "prioritized": true,
@@ -311,7 +311,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     // Feasts
     {
       "key": "holyFamily",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": Dates.holyFamily( year ),
       "data": {
         "prioritized": true,
@@ -325,7 +325,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "baptismOfTheLord",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": Dates.baptismOfTheLord( year, epiphanyOnJan6 ),
       "data": {
         "prioritized": true,
@@ -339,7 +339,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "presentationOfTheLord",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": Dates.presentationOfTheLord( year ),
       "data": {
         "prioritized": true,
@@ -353,7 +353,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "transfiguration",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": Dates.transfiguration( year ),
       "data": {
         "prioritized": true,
@@ -367,7 +367,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     },
     {
       "key": "theExaltationOfTheHolyCross",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": Dates.theExaltationOfTheHolyCross( year ),
       "data": {
         "prioritized": true,
@@ -382,7 +382,7 @@ let dates = (year, christmastideEnds, epiphanyOnJan6 = false, corpusChristiOnThu
     // Memorials
     {
       "key": "immaculateHeartOfMary",
-      "type": Types[4],
+      "type": Types.FEAST,
       "moment": Dates.immaculateHeartOfMary( year ),
       "data": {
         "prioritized": true,

--- a/src/lib/Seasons.js
+++ b/src/lib/Seasons.js
@@ -40,7 +40,7 @@ const _epiphany = (y, epiphanyOnJan6 = false) => {
   _.each( before, day => {
     days.push({
       moment: day,
-      type: _.last( Types ),
+      type: Types.FERIA,
       name: Utils.localize({
         key: 'epiphany.before',
         day: day.format('dddd')
@@ -63,7 +63,7 @@ const _epiphany = (y, epiphanyOnJan6 = false) => {
   _.each( after, day => {
     days.push({
       moment: day,
-      type: _.last( Types ),
+      type: Types.FERIA,
       name: Utils.localize({
         key: 'epiphany.after',
         day: day.format('dddd')
@@ -95,7 +95,7 @@ const _holyWeek = y => {
   _.each( dates, (date, i) => {
     days.push({
       moment: date,
-      type: Types[3],
+      type: Types.HOLY_WEEK,
       name: Utils.localize({
         key: 'holyWeek.feria',
         day: date.format('dddd')
@@ -327,7 +327,7 @@ const earlyOrdinaryTime = (y, christmastideEnds, epiphanyOnJan6 = false) => {
   _.each( Dates.daysOfEarlyOrdinaryTime(y, christmastideEnds, epiphanyOnJan6), ( value, i ) => {
     days.push({
       moment: value,
-      type: ( _.eq( value.day(), 0 ) ? Types[1] : _.last( Types ) ),
+      type: ( _.eq( value.day(), 0 ) ? Types.SUNDAY : Types.FERIA ),
       name: Utils.localize({
         key: ( _.eq( value.day(), 0 ) ? 'ordinaryTime.sunday' : 'ordinaryTime.feria' ),
         day: value.format('dddd'),
@@ -412,7 +412,7 @@ const laterOrdinaryTime = y => {
 
     days.push({
       moment: value,
-      type: ( _.eq( value.day(), 0 ) ? Types[1] : _.last( Types ) ),
+      type: ( _.eq( value.day(), 0 ) ? Types.SUNDAY : Types.FERIA ),
       name: Utils.localize({
         key: ( _.eq( value.day(), 0 ) ? 'ordinaryTime.sunday' : 'ordinaryTime.feria' ),
         day: value.format('dddd'),
@@ -494,7 +494,7 @@ const lent = y => {
   _.each( daysOfLent, (value, i) => {
     days.push({
       moment: value,
-      type: _.last( Types ), // Feria
+      type: Types.FERIA,
       name: Utils.localize({
         key: ( _.gt( i, 0 ) && _.lt( i, 4 ) ) ?  'lent.day_after_ash_wed' : 'lent.feria',
         day: value.format('dddd'),
@@ -514,7 +514,7 @@ const lent = y => {
   _.each( sundaysOfLent, ( value, i ) => {
     sundays.push({
       moment: value,
-      type: Types[1],
+      type: Types.SUNDAY,
       name: Utils.localize({
         key: 'lent.sunday',
         day: value.format('dddd'),
@@ -617,7 +617,7 @@ const eastertide = y => {
   _.each( d, (value, i) => {
     days.push({
       moment: value,
-      type: ( _.gt( i, 0 ) && _.lt( i, 7 ) ) ? _.head( Types ): _.last( Types ),
+      type: ( _.gt( i, 0 ) && _.lt( i, 7 ) ) ? Types.SOLEMNITY : Types.FERIA,
       name: Utils.localize({
         key: ( _.gt( i, 0 ) && _.lt( i, 7 ) ) ?  'eastertide.octave' : 'eastertide.feria',
         day: value.format('dddd'),
@@ -640,7 +640,7 @@ const eastertide = y => {
   _.each( s, ( value, i ) => {
     sundays.push({
       moment: value,
-      type: Types[1],
+      type: Types.SUNDAY,
       name: Utils.localize({
         key: 'eastertide.sunday',
         day: value.format('dddd'),

--- a/src/lib/Utils.js
+++ b/src/lib/Utils.js
@@ -112,8 +112,7 @@ const localizeDates = (dates, source = 'sanctoral') => {
   });
 };
 
-// Types[1]: Sunday, _.last(Types) Feria
-const getTypeByDayOfWeek = d => _.eq(d, 0) ? Types[1]: _.last(Types);
+const getTypeByDayOfWeek = d => _.eq(d, 0) ? Types.SUNDAY : Types.FERIA;
 
 const convertMomentObjectToIsoDateString = (items = []) => {
   _.each(items, (item, key) => { // Loop through the date array

--- a/test/03_calendar.js
+++ b/test/03_calendar.js
@@ -249,7 +249,7 @@ describe('Testing calendar generation functions', function() {
 
       it('The proper color of a Memorial or a Feast is white except for martyrs in which case it is red', function() {
         var calendar = Calendar.calendarFor({ query: { group: 'types' }}, true );
-        _.each( _.get( calendar, Types[4] ), function( d ) {
+        _.each( _.get( calendar, Types.FEAST ), function( d ) {
           if ( _.eq( d.key, 'theExaltationOfTheHolyCross') ) {
             d.data.meta.liturgicalColor.key.should.be.eql( LiturgicalColors.RED.key );
           }
@@ -267,7 +267,7 @@ describe('Testing calendar generation functions', function() {
             }
           }
         });
-        _.each( _.get( calendar, Types[5] ), function( d ) {
+        _.each( _.get( calendar, Types.MEMORIAL ), function( d ) {
           if ( !_.isUndefined( d.data.meta.titles ) ) {
             if ( _.includes( d.data.meta.titles, Titles.MARTYR ) ) {
               d.data.meta.liturgicalColor.key.should.be.eql( LiturgicalColors.RED.key );
@@ -284,7 +284,7 @@ describe('Testing calendar generation functions', function() {
 
       it('The proper color for the Chair of Peter and the Conversion of St. Paul is white, although both St. Peter and St. Paul were martyrs.', function() {
         var calendar = Calendar.calendarFor({ query: { group: 'types' }}, true );
-        _.each( _.get( calendar, Types[4] ), function( d ) {
+        _.each( _.get( calendar, Types.FEAST ), function( d ) {
           if ( _.eq( d.key, 'chairOfSaintPeter' ) || _.eq( d.key, 'conversionOfSaintPaulApostle' ) ) {
             d.data.meta.liturgicalColor.should.be.eql( LiturgicalColors.WHITE );
           }

--- a/test/04_calendar_date_overrides.js
+++ b/test/04_calendar_date_overrides.js
@@ -311,7 +311,7 @@ describe('Testing national calendar overrides', function() {
       var saintMatthiasGermany = _.find(germanyDates, function(d) {
         return _.eq(d.key, 'saintMatthiasTheApostle');
       });
-      saintMatthiasGermany.type.should.be.eql(Types[5]);
+      saintMatthiasGermany.type.should.be.eql(Types.MEMORIAL);
     });
   });
 
@@ -328,8 +328,8 @@ describe('Testing national calendar overrides', function() {
       var saintChristopherMagallanesAndCompanionsMartyrsMexico = _.find(mexicoDates, function(d) {
         return _.eq(d.key, 'saintChristopherMagallanesAndCompanionsMartyrs');
       });
-      saintChristopherMagallanesAndCompanionsMartyrs.type.should.be.eql(Types[6]);
-      saintChristopherMagallanesAndCompanionsMartyrsMexico.type.should.be.eql(Types[5]);
+      saintChristopherMagallanesAndCompanionsMartyrs.type.should.be.eql(Types.OPT_MEMORIAL);
+      saintChristopherMagallanesAndCompanionsMartyrsMexico.type.should.be.eql(Types.MEMORIAL);
     });
   });
 
@@ -349,8 +349,8 @@ describe('Testing national calendar overrides', function() {
       var saintLadislausSlovakia = _.find(slovakiaDates, function(d) {
         return _.eq(d.key, 'saintLadislaus');
       });
-      saintLadislausHungary.type.should.be.eql(Types[4]);
-      saintLadislausSlovakia.type.should.be.eql(Types[6]);
+      saintLadislausHungary.type.should.be.eql(Types.FEAST);
+      saintLadislausSlovakia.type.should.be.eql(Types.OPT_MEMORIAL);
     });
   });
 
@@ -361,7 +361,7 @@ describe('Testing national calendar overrides', function() {
       var ourLadyOfSorrows = _.find(dates, function(d) {
         return _.eq(d.key, 'ourLadyOfSorrows');
       });
-      ourLadyOfSorrows.type.should.be.eql(Types[5]);
+      ourLadyOfSorrows.type.should.be.eql(Types.MEMORIAL);
       ourLadyOfSorrows.moment.isSame(moment.utc({ year: 2018, month: 8, day: 15 })).should.be.ok();
     });
 
@@ -373,7 +373,7 @@ describe('Testing national calendar overrides', function() {
       var ourLadyOfSorrows = _.find(maltaDates, function(d) {
         return _.eq(d.key, 'ourLadyOfSorrows');
       });
-      ourLadyOfSorrows.type.should.be.eql(Types[4]);
+      ourLadyOfSorrows.type.should.be.eql(Types.FEAST);
       ourLadyOfSorrows.moment.isSame(moment.utc({ year: 2015, month: 3, day: 15 })).should.be.ok();
     });
 
@@ -397,7 +397,7 @@ describe('Testing national calendar overrides', function() {
       var ourLadyOfSorrows = _.find(slovakiaDates, function(d) {
         return _.eq(d.key, 'ourLadyOfSorrows');
       });
-      ourLadyOfSorrows.type.should.be.eql(Types[0]);
+      ourLadyOfSorrows.type.should.be.eql(Types.SOLEMNITY);
       ourLadyOfSorrows.moment.isSame(moment.utc({ year: 2018, month: 8, day: 15 })).should.be.ok();
     });
 

--- a/test/07_use_cases.js
+++ b/test/07_use_cases.js
@@ -61,7 +61,7 @@ describe("Testing specific feasts and memorials", function() {
       });
       saintMaryMagdalene.moment.date().should.be.eql(22);
       saintMaryMagdalene.moment.month().should.be.eql(6);
-      saintMaryMagdalene.type.should.be.eql(Types[4]);
+      saintMaryMagdalene.type.should.be.eql(Types.FEAST);
     });
   });
 
@@ -74,8 +74,8 @@ describe("Testing specific feasts and memorials", function() {
       let popeSaintJohnPaulII = _.find(dates, function(d) {
         return _.eq(d.key, "popeSaintJohnPaulII");
       });
-      popeSaintJohnXXIII.type.should.be.eql(Types[6]);
-      popeSaintJohnPaulII.type.should.be.eql(Types[6]);
+      popeSaintJohnXXIII.type.should.be.eql(Types.OPT_MEMORIAL);
+      popeSaintJohnPaulII.type.should.be.eql(Types.OPT_MEMORIAL);
     });
   });
 


### PR DESCRIPTION
* Improve code readability for rank types of celebrations.
* eslint: better es6 and Babel support.

resolve #109 

this will help to move forward on #110 

@jarosz, I worked on it last night, and when I opened a PR today I discovered your work [here](https://github.com/jarosz/romcal/commit/92ecc8ba14a99d7cc81ca71bb8fc6d8099bf790f). Our contributions was very close (extend an Array instead of using a Map object, to offer syntactic sugar). And I've include some of your code comments and the way you declare new type properties 👍 (with the `writable: false`). 
Thank you very much for your contribution. I've added you as a co-author of this commit 😉