### PR TITLE
Fix installation script when romcal is installed as a node dependency

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
 # Version history
 
-## 1.3.0-rc.1 /2020-12-01
+## 1.3.0-rc.2 /2020-01-13
+* Fix installation script when romcal is installed as a node dependency
+
+## 1.3.0-rc.1 /2020-01-12
 * Drop Shrove Monday and Tuesday from the general calendar (#90).
 * Refactor rank types of celebrations (#109).
 * Various bug fixes and improvements (#105 #133 #129 #44).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romcal",
-  "version": "1.3.0-rc1",
+  "version": "1.3.0-rc2",
   "description": "Utility library that outputs the Liturgical Calendar used by the Roman Rite (Western Church)",
   "main": "dist/index.js",
   "module": "src/index.js",
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "prepack": "npm run build && npm test",
-    "install": "npm run build",
+    "prepublish": "npm run build",
     "build": "npm run build:babel && npm run build:webpack",
     "build:babel": "babel src --out-dir dist",
     "build:webpack": "webpack-cli --config webpack.config.js",


### PR DESCRIPTION
Use `prepublish` (instead of `install`): Run BEFORE the package is packed and published, as well as on local `npm install` without any arguments.

- For romcal contributors or when publishing a new version of romcal, it will change nothing. 
- But this fix an issue when romcal is installed as a node dependency, from another node module (the `install` script from romcal was executed when it was not necessary, and it caused an error)
