### PR TITLE
Rename the `prepublish` npm handler to `prepare`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "romcal",
-  "version": "1.3.0-rc1",
+  "version": "1.3.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "prepack": "npm run build && npm test",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "build": "npm run build:babel && npm run build:webpack",
     "build:babel": "babel src --out-dir dist",
     "build:webpack": "webpack-cli --config webpack.config.js",


### PR DESCRIPTION
Rename the `prepublish` npm handler to `prepare`, since `prepublish` has been deprecated: https://docs.npmjs.com/misc/scripts#deprecation-note