### PR TITLE
Pre-release tidy-up

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## 1.3.0 /2020-01-25 <a name="1.3.0"></a>
 
-This release changed a lot since [1.2.4](#1.2.4), therefore we list here only the main changes and small changes were combined. For more thorough list of changes, check the release notes for [1.3.0-beta.1](#1.3.0-beta.1), [1.3.0-beta.2](#1.3.0-beta.2), [1.3.0-beta.3](#1.3.0-beta.3), [1.3.0-rc.1](#1.3.0-rc.1) and [1.3.0-rc.2](#1.3.0-rc.2).
+romcal changed a lot since [1.2.4](#1.2.4), therefore we list here only the main changes and small changes were combined. For more thorough list of changes, check the release notes for [1.3.0-beta.1](#1.3.0-beta.1), [1.3.0-beta.2](#1.3.0-beta.2), [1.3.0-beta.3](#1.3.0-beta.3), [1.3.0-rc.1](#1.3.0-rc.1) and [1.3.0-rc.2](#1.3.0-rc.2).
 
 ### General changes
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,14 +19,14 @@ romcal changed a lot since [1.2.4](#1.2.4), therefore we list here only the main
 
 ### Calendar and celebrations
 
-- Added national calendars for Czech Republic and Slovakia.
+- Added national calendars for Czech Republic, Italy and Slovakia.
 - Drop Shrove Monday and Tuesday from the General Roman Calendar ([issue #90](https://github.com/pejulian/romcal/issues/90)).
 - Epiphany is always celebrated on Jan 6 in Slovakia ([issue #29](https://github.com/pejulian/romcal/issues/29)).
 - Apply changes in the General Roman Calendar made by the Holy See.
 
 ### Localization
 
-- Add Slovak locale files.
+- Add Italian and Slovak locale files.
 - Some localization keys where renamed in order to confirm with official English names of the celebrations.
 
 ### Build process
@@ -34,7 +34,7 @@ romcal changed a lot since [1.2.4](#1.2.4), therefore we list here only the main
 - Update and simplify the build process.
 - Add automated build process to transpile the code after installing and before publishing.
 - Distribution files are now not included anymore in the codebase.
-- In addition to the `romcal.bundle.min.js` file (for browsers), source code is also transpiled by Babel in the `dist/` directory. This makes it easier to include romcal in any node.js package.
+- In addition to the `romcal.bundle.min.js` file (for browsers), source code is also transpiled by Babel and Webpack in the `dist/` directory. This feature makes it possible to use romcal directly in the browser, so not only in a node.js package or environment (babel and webpack allow to have the same codebase for backend/node.js and frontend/browser).
 - Added more test cases for better test coverage.
 
 ### Other changes and fixes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # Version history
 
-## 1.3.0 /2020-01-25 <a name="1.3.0"></a>
+## 1.3.0 /2020-01-26 <a name="1.3.0"></a>
 
 romcal changed a lot since [1.2.4](#1.2.4), therefore we list here only the main changes and small changes were combined. For more thorough list of changes, check the release notes for [1.3.0-beta.1](#1.3.0-beta.1), [1.3.0-beta.2](#1.3.0-beta.2), [1.3.0-beta.3](#1.3.0-beta.3), [1.3.0-rc.1](#1.3.0-rc.1) and [1.3.0-rc.2](#1.3.0-rc.2).
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,110 +1,159 @@
 # Version history
 
-## 1.3.0 /2020-01-25
+## 1.3.0 /2020-01-25 <a name="1.3.0"></a>
 
+This release changed a lot since [1.2.4](#1.2.4), therefore we list here only the main changes and small changes were combined. For more thorough list of changes, check the release notes for [1.3.0-beta.1](#1.3.0-beta.1), [1.3.0-beta.2](#1.3.0-beta.2), [1.3.0-beta.3](#1.3.0-beta.3), [1.3.0-rc.1](#1.3.0-rc.1) and [1.3.0-rc.2](#1.3.0-rc.2).
 
-## 1.3.0-rc.2 /2020-01-13
-* Fix installation script when romcal is installed as a node dependency
+### General changes
 
-## 1.3.0-rc.1 /2020-01-12
-* Drop Shrove Monday and Tuesday from the general calendar (#90).
-* Refactor rank types of celebrations (#109).
-* Various bug fixes and improvements (#105 #133 #129 #44).
-* A lot of localization and calendar improvements (#11 #25 #30 #35 #38 #39 #42 #46 #111 #115 #116 #118 #123 #127 #139 #143).
+- Revamp the code to use ES6 syntax.
+- Drop support for Node v4, v5.
+- Integrated module with `std/esm` to read `.mjs` files and `babel` to ensure compatibility and seamless usage with lower version of node and requiring via CommonJS.
+- Expose constants and calendar helper functions and via module exports.
+- Refactor rank types of celebrations ([issue #109](https://github.com/pejulian/romcal/issues/109)).
 
-## 1.3.0-beta.3 /2019-12-10
-* Update and simplify the build process.
-* Add automated build process to transpile the code after installing and before publishing.
-* Distribution files are now not included anymore in the codebase.
-* In addition to the `romcal.bundle.min.js` file (for browsers), source code is also transpiled by Babel in the `dist/` directory. This makes it easier to include romcal in any node.js package.
+### New features
 
-## 1.3.0-beta.2 /2019-12-06
-* Update node dependencies.
-* The `@std/esm` package has been deprecated in favour of `esm`. Also `esm` have limited the `.mjs` files to basic functionality without support for esm options, to align with the current experimental support in Node. [More details here](https://github.com/standard-things/esm/issues/696). According to that all `.mjs` files in the `romcal` project have been renamed back to `.js`.
-* Locales management and pickup in romcal have been refactored, and it now behaves like Moment.js (used by romcal) or the general approach for i18n in app development: locale containing region like `fr-CA` will gracefully fall back to `fr` if a localisation key isn't in `fr-CA` or if `fr-CA.js` doesn't exits in the `src/locales` directory. In the end, it always falls back to `en`, which is the default language in romcal. Full explanations have been added to the `README.md`.
-* Locale files have been renamed to kebab-case with capitalized regions to follow the IETF Language Codes standards and be close to the general conventions in software development for i18n.
-* In locale files, the `general` and `national` parts are now merged in a new `sanctoral` part. This will avoid potential duplicated or missing keys between these 2 parts, particularly when a celebration is move from the general to the national calendar. Also, keys in celebrations and the new sanctoral have been sorted alphabetically. ([#97](https://github.com/romcal/romcal/pull/97))
-* Italian translation has been added in romcal ([#94](https://github.com/romcal/romcal/issues/94)).
-* In Christian calendars, Sunday is the first day of the week ([#103](https://github.com/romcal/romcal/issues/103))
-* Drop Shrove Monday and Tuesday from the general calendar ([#90](https://github.com/romcal/romcal/issues/90)).
-* Potential breaking changes:
-    - The `WEEKDAY` type is renamed to `FERIA` ([#88](https://github.com/romcal/romcal/issues/88))
-* Fixes:
-    - Depending on how the language string is set in romcal, one could get bilingual results when part of a string being in the chosen language and the default English (locale lookup for date name strings are based on Moment.js, not romcal). Locale files are now managed the same way as Moment.js. ([#85](https://github.com/romcal/romcal/issues/85))
-    - Remove some duplicate keys in `enUs.mjs` ([#42](https://github.com/romcal/romcal/pull/42), [#35](https://github.com/romcal/romcal/pull/35))
+- Introduce the new `drop` property that allows national calendars to omit unwanted celebrations from their output ([issue #14](https://github.com/pejulian/romcal/issues/14)).
+- Introduce new `christmastideIncludesTheSeasonOfEpiphany` flag to allow output to include or exclude the "season" of Epiphany from being merged into Christmastide.
 
-## 1.3.0-beta.1 /2018-03-05
-* Revamp code to use ES6 syntax
-* Dropped support for Node v4, v5.
-* Integrated module with `std/esm` to read `.mjs` files and `babel` to ensure compatibility and seamless usage with lower version of node and requiring via CommonJS
-* Expose constants and calendar helper functions and via module exports
-* Various unreported bug fixes
-* Added locale files for Czech Republic and Slovakia
-* Added national calendars for Czech Republick and Slovakia
-* Added more test cases for better test coverage
-* Fixes:
-    - [issue #2](https://github.com/pejulian/romcal/issues/2)
-        + The command `npm run build` now generates an ES5 distribution bundle of `romcal` that is UMD compliant.
-    - [issue #9](https://github.com/pejulian/romcal/issues/9)
-        + typo fix for `src/calendars/*sriLanka*.mjs`
-    - [issue #10](https://github.com/pejulian/romcal/issues/10)
-        + removed duplicate celebration with different key names for
-            * `saintsCyrilMonkAndMethodiusBishop` replaces `saintsCyrilAndMethodiusSlavicMissionaries`
-            * `assumption` replaces `assumptionOfTheBlessedVirginMaryPrincipalPatronessOfFrance`
-            * Removed duplicate key `saintAnselmOfCanterburyBishopAndDoctorOfTheChurch` defined in the national calendar in `src/locales/en.mjs`
-            * Removed duplicate `birthOfTheBlessedVirginMary` defined in the national calendar in `src/locales/en.mjs`
-            * `blessedBoleslawaMariaLamentVirginAndSaintAngelaMericiVirgin` replaces `blessedBoleslawaMariaLamentVirginsaintAngelaMericiVirgin` and `blessedBoleslawaMariaLamentVirgin` and duplicate removed
-            * `blessedInacioDeAzevedoPriestAndCompanionsMartyrs` replaces `blessedInacioDeAzevedoPriestAndMartyr` and duplicate removed
-            * `blessedLauraVicunaVirgin` replaces `blessedLauraVicuna` and duplicate removed
-            * `saintMatthiasApostle` renamed to `saintMatthiasTheApostle` and duplicate removed
-            * Removed duplicate keys for `saintCyrilOfAlexandriaBishopAndDoctor` and `saintCatherineOfAlexandriaVirginAndMartyr`
-            * Remove duplicate keys for `saintBenedictOfNursiaAbbot`
-            * Remove duplicate keys for `saintApollinaris`
-            * Rename `saintGallAbbot` to `saintGallAbbotAndMissionary`
-            * Rename `saintCristobalMagallanesAndCompanionsMartyrs` to `saintChristopherMagallanesAndCompanionsMartyrs`
-    - [issue #11](https://github.com/pejulian/romcal/issues/11)
-        + Renamed `triumphOfTheCross` to `theExaltationOfTheHolyCross`
-    - [issue #12](https://github.com/pejulian/romcal/issues/12)
-        + `saintsFabianAndSebastianPopeAndMartyrs ` renamed to `saintFabianPopeAndMartyrAndSaintSebastianPopeAndMartyr`
-    - [issue #14](https://github.com/pejulian/romcal/issues/14)
-        + Introduce the new `drop` property that allows national calendars to omit unwanted celebrations from their output
-        + Introduce new `christmastideIncludesTheSeasonOfEpiphany` flag to allow output to include or exclude the "season" of Epiphany from being merged into Christmastide
-        + Fix issue where calendar options always end up using their defaults even though an option has been specified
-    - [issue #15](https://github.com/pejulian/romcal/issues/15)
-        + Renamed `blessedCaTherineOfSaintAugustineVirgin` to `blessedCatherineOfSaintAugustineVirgin` (fix typo with `T`)
-    - [issue #16](https://github.com/pejulian/romcal/issues/16)
-        + Renamed `saintsAndrewZoerardusAndBenedictEremites` to `saintsAndrewZoerardusAndBenedictHermits` (fix typo)
-    - [issue #17](https://github.com/pejulian/romcal/issues/17)
-        + Remove duplicate keys for `ourLadyOfSorrows`
-    - [issue #27](https://github.com/pejulian/romcal/issues/27)
-    - [issue #28](https://github.com/pejulian/romcal/issues/28)
-    - [issue #29](https://github.com/pejulian/romcal/issues/29)
-        + Epiphany is always celebrated on Jan 6 in Slovakia
+### Calendar and celebrations
 
-## 1.2.4
-* Added credits in the description section in `README.md`.
-* Drop support of Node.js `v0.10.x`, `v0.11.x`, `v0.12.x`.
-* Updated French Calendar.
-* Fixes:
-    * [pull #8](https://github.com/romcal/romcal/pull/8)
-        * Compute correctly the week numbers in Lent.<br>
-          During lent, weeks was starting on Wednesday instead of Sunday. This fix remove the first 4 days of lent (Ash Wednesday to Saturday) when computing the week number.
-    * [issue #52](https://github.com/romcal/romcal/issues/52)
-        * Duplicate entries for the same date.
-    * [issue #63](https://github.com/romcal/romcal/issues/63)
-        * Updated romcal to use correct lodash method for finding uniques with a criterion.
-    * [pull #78](https://github.com/romcal/romcal/pull/78)
-        * Add missing type: `MARTYR` & fix wrong specified types in brazil calendar.
+- Added national calendars for Czech Republic and Slovakia.
+- Drop Shrove Monday and Tuesday from the General Roman Calendar ([issue #90](https://github.com/pejulian/romcal/issues/90)).
+- Epiphany is always celebrated on Jan 6 in Slovakia ([issue #29](https://github.com/pejulian/romcal/issues/29)).
+- Apply changes in the General Roman Calendar made by the Holy See.
 
-## 1.2.3 / 2017-03-21
-* Added French translations for France, Canada and Belgium.
-* Fix issue where national feasts appear more than once in the calendar output
+### Localization
 
-## 1.2.2 / 2017-03-21
-* Merge PRs containing bug fixes and improvements, thanks [Etienne Magnier](https://github.com/emagnier) and [Damiaan Dufaux](https://github.com/Dev1an)
+- Add Slovak locale files.
+- Some localization keys where renamed in order to confirm with official English names of the celebrations.
 
-## 1.2.1
-* Added caching mechanism for common celebration dates in the liturgical calendar to improve calendar processing output performance. Added more titles metadata to national and general celebrations.
+### Build process
 
-## 1.2.0
-* Major rewrite for better extensibility and functionality. All previous revisions have been marked for deprecation in favor of this new rewrite.
+- Update and simplify the build process.
+- Add automated build process to transpile the code after installing and before publishing.
+- Distribution files are now not included anymore in the codebase.
+- In addition to the `romcal.bundle.min.js` file (for browsers), source code is also transpiled by Babel in the `dist/` directory. This makes it easier to include romcal in any node.js package.
+- Added more test cases for better test coverage.
+
+### Other changes and fixes
+
+- Fix issue where calendar options always end up using their defaults even though an option has been specified
+- Various other bug, duplicate and typo fixes, and other improvements.
+
+## 1.3.0-rc.2 /2020-01-13 <a name="1.3.0-rc.2"></a>
+
+- Fix installation script when romcal is installed as a node dependency
+
+## 1.3.0-rc.1 /2020-01-12 <a name="1.3.0-rc.1"></a>
+
+- Drop Shrove Monday and Tuesday from the general calendar (#90).
+- Refactor rank types of celebrations (#109).
+- Various bug fixes and improvements (#105 #133 #129 #44).
+- A lot of localization and calendar improvements (#11 #25 #30 #35 #38 #39 #42 #46 #111 #115 #116 #118 #123 #127 #139 #143).
+
+## 1.3.0-beta.3 /2019-12-10 <a name="1.3.0-beta.3"></a>
+
+- Update and simplify the build process.
+- Add automated build process to transpile the code after installing and before publishing.
+- Distribution files are now not included anymore in the codebase.
+- In addition to the `romcal.bundle.min.js` file (for browsers), source code is also transpiled by Babel in the `dist/` directory. This makes it easier to include romcal in any node.js package.
+
+## 1.3.0-beta.2 /2019-12-06 <a name="1.3.0-beta.2"></a>
+
+- Update node dependencies.
+- The `@std/esm` package has been deprecated in favour of `esm`. Also `esm` have limited the `.mjs` files to basic functionality without support for esm options, to align with the current experimental support in Node. [More details here](https://github.com/standard-things/esm/issues/696). According to that all `.mjs` files in the `romcal` project have been renamed back to `.js`.
+- Locales management and pickup in romcal have been refactored, and it now behaves like Moment.js (used by romcal) or the general approach for i18n in app development: locale containing region like `fr-CA` will gracefully fall back to `fr` if a localisation key isn't in `fr-CA` or if `fr-CA.js` doesn't exits in the `src/locales` directory. In the end, it always falls back to `en`, which is the default language in romcal. Full explanations have been added to the `README.md`.
+- Locale files have been renamed to kebab-case with capitalized regions to follow the IETF Language Codes standards and be close to the general conventions in software development for i18n.
+- In locale files, the `general` and `national` parts are now merged in a new `sanctoral` part. This will avoid potential duplicated or missing keys between these 2 parts, particularly when a celebration is move from the general to the national calendar. Also, keys in celebrations and the new sanctoral have been sorted alphabetically. ([#97](https://github.com/romcal/romcal/pull/97))
+- Italian translation has been added in romcal ([#94](https://github.com/romcal/romcal/issues/94)).
+- In Christian calendars, Sunday is the first day of the week ([#103](https://github.com/romcal/romcal/issues/103))
+- Drop Shrove Monday and Tuesday from the general calendar ([#90](https://github.com/romcal/romcal/issues/90)).
+- Potential breaking changes:
+  - The `WEEKDAY` type is renamed to `FERIA` ([#88](https://github.com/romcal/romcal/issues/88))
+- Fixes:
+  - Depending on how the language string is set in romcal, one could get bilingual results when part of a string being in the chosen language and the default English (locale lookup for date name strings are based on Moment.js, not romcal). Locale files are now managed the same way as Moment.js. ([#85](https://github.com/romcal/romcal/issues/85))
+  - Remove some duplicate keys in `enUs.mjs` ([#42](https://github.com/romcal/romcal/pull/42), [#35](https://github.com/romcal/romcal/pull/35))
+
+## 1.3.0-beta.1 /2018-03-05 <a name="1.3.0-beta.1"></a>
+
+- Revamp the code to use ES6 syntax
+- Dropped support for Node v4, v5.
+- Integrated module with `std/esm` to read `.mjs` files and `babel` to ensure compatibility and seamless usage with lower version of node and requiring via CommonJS
+- Expose constants and calendar helper functions and via module exports
+- Various unreported bug fixes
+- Added locale files for ~~Czech Republic and~~ Slovakia
+- Added national calendars for Czech Republic and Slovakia
+- Added more test cases for better test coverage
+- Fixes:
+  - [issue #2](https://github.com/pejulian/romcal/issues/2)
+    - The command `npm run build` now generates an ES5 distribution bundle of `romcal` that is UMD compliant.
+  - [issue #9](https://github.com/pejulian/romcal/issues/9)
+    - typo fix for `src/calendars/*sriLanka*.mjs`
+  - [issue #10](https://github.com/pejulian/romcal/issues/10)
+    - removed duplicate celebration with different key names for
+      - `saintsCyrilMonkAndMethodiusBishop` replaces `saintsCyrilAndMethodiusSlavicMissionaries`
+      - `assumption` replaces `assumptionOfTheBlessedVirginMaryPrincipalPatronessOfFrance`
+      - Removed duplicate key `saintAnselmOfCanterburyBishopAndDoctorOfTheChurch` defined in the national calendar in `src/locales/en.mjs`
+      - Removed duplicate `birthOfTheBlessedVirginMary` defined in the national calendar in `src/locales/en.mjs`
+      - `blessedBoleslawaMariaLamentVirginAndSaintAngelaMericiVirgin` replaces `blessedBoleslawaMariaLamentVirginsaintAngelaMericiVirgin` and `blessedBoleslawaMariaLamentVirgin` and duplicate removed
+      - `blessedInacioDeAzevedoPriestAndCompanionsMartyrs` replaces `blessedInacioDeAzevedoPriestAndMartyr` and duplicate removed
+      - `blessedLauraVicunaVirgin` replaces `blessedLauraVicuna` and duplicate removed
+      - `saintMatthiasApostle` renamed to `saintMatthiasTheApostle` and duplicate removed
+      - Removed duplicate keys for `saintCyrilOfAlexandriaBishopAndDoctor` and `saintCatherineOfAlexandriaVirginAndMartyr`
+      - Remove duplicate keys for `saintBenedictOfNursiaAbbot`
+      - Remove duplicate keys for `saintApollinaris`
+      - Rename `saintGallAbbot` to `saintGallAbbotAndMissionary`
+      - Rename `saintCristobalMagallanesAndCompanionsMartyrs` to `saintChristopherMagallanesAndCompanionsMartyrs`
+  - [issue #11](https://github.com/pejulian/romcal/issues/11)
+    - Renamed `triumphOfTheCross` to `theExaltationOfTheHolyCross`
+  - [issue #12](https://github.com/pejulian/romcal/issues/12)
+    - `saintsFabianAndSebastianPopeAndMartyrs ` renamed to `saintFabianPopeAndMartyrAndSaintSebastianPopeAndMartyr`
+  - [issue #14](https://github.com/pejulian/romcal/issues/14)
+    - Introduce the new `drop` property that allows national calendars to omit unwanted celebrations from their output
+    - Introduce new `christmastideIncludesTheSeasonOfEpiphany` flag to allow output to include or exclude the "season" of Epiphany from being merged into Christmastide
+    - Fix issue where calendar options always end up using their defaults even though an option has been specified
+  - [issue #15](https://github.com/pejulian/romcal/issues/15)
+    - Renamed `blessedCaTherineOfSaintAugustineVirgin` to `blessedCatherineOfSaintAugustineVirgin` (fix typo with `T`)
+  - [issue #16](https://github.com/pejulian/romcal/issues/16)
+    - Renamed `saintsAndrewZoerardusAndBenedictEremites` to `saintsAndrewZoerardusAndBenedictHermits` (fix typo)
+  - [issue #17](https://github.com/pejulian/romcal/issues/17)
+    - Remove duplicate keys for `ourLadyOfSorrows`
+  - [issue #27](https://github.com/pejulian/romcal/issues/27)
+  - [issue #28](https://github.com/pejulian/romcal/issues/28)
+  - [issue #29](https://github.com/pejulian/romcal/issues/29)
+    - Epiphany is always celebrated on Jan 6 in Slovakia
+
+## 1.2.4 <a name="1.2.4"></a>
+
+- Added credits in the description section in `README.md`.
+- Drop support of Node.js `v0.10.x`, `v0.11.x`, `v0.12.x`.
+- Updated French Calendar.
+- Fixes:
+  - [pull #8](https://github.com/romcal/romcal/pull/8)
+    - Compute correctly the week numbers in Lent.<br>
+      During lent, weeks was starting on Wednesday instead of Sunday. This fix remove the first 4 days of lent (Ash Wednesday to Saturday) when computing the week number.
+  - [issue #52](https://github.com/romcal/romcal/issues/52)
+    - Duplicate entries for the same date.
+  - [issue #63](https://github.com/romcal/romcal/issues/63)
+    - Updated romcal to use correct lodash method for finding uniques with a criterion.
+  - [pull #78](https://github.com/romcal/romcal/pull/78)
+    - Add missing type: `MARTYR` & fix wrong specified types in brazil calendar.
+
+## 1.2.3 / 2017-03-21 <a name="1.2.3"></a>
+
+- Added French translations for France, Canada and Belgium.
+- Fix issue where national feasts appear more than once in the calendar output
+
+## 1.2.2 / 2017-03-21 <a name="1.2.2"></a>
+
+- Merge PRs containing bug fixes and improvements, thanks [Etienne Magnier](https://github.com/emagnier) and [Damiaan Dufaux](https://github.com/Dev1an)
+
+## 1.2.1 <a name="1.2.1"></a>
+
+- Added caching mechanism for common celebration dates in the liturgical calendar to improve calendar processing output performance. Added more titles metadata to national and general celebrations.
+
+## 1.2.0 <a name="1.2.0"></a>
+
+- Major rewrite for better extensibility and functionality. All previous revisions have been marked for deprecation in favor of this new rewrite.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # Version history
 
+## 1.3.0 /2020-01-25
+
+
 ## 1.3.0-rc.2 /2020-01-13
 * Fix installation script when romcal is installed as a node dependency
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See [contributing](CONTRIBUTING.md) for more information.
   - [Overriding a date by its key](#overridingByKey)
 - [Removing general dates in national calendar output](#removingDates)
   - [The `drop` keyword](#dropKeyword)
-- [localizing celebration names](#localization)
+- [Localizing celebration names](#localization)
 
 ## Description <a name="desc"></a>
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,22 @@
     "email": "bleushade@gmail.com",
     "url": "https://github.com/pejulian"
   },
+  "contributors": [
+    {
+      "name": "Etienne Magnier",
+      "email": "etienne.magnier@gmail.com",
+      "url": "https://github.com/emagnier"
+    },
+    {
+      "name": "Jacek Roszkowski",
+      "url": "https://github.com/jarosz"
+    },
+    {
+      "name": "Tukusej’s Sirs",
+      "email": "tukusejssirs@protonmail.com",
+      "url": "https://github.com/tukusejssirs"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/romcal/romcal/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romcal",
-  "version": "1.3.0-rc2",
+  "version": "1.3.0",
   "description": "Utility library that outputs the Liturgical Calendar used by the Roman Rite (Western Church)",
   "main": "dist/index.js",
   "module": "src/index.js",
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pejulian/romcal.git"
+    "url": "git+https://github.com/romcal/romcal.git"
   },
   "keywords": [
     "roman",
@@ -37,9 +37,9 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/pejulian/romcal/issues"
+    "url": "https://github.com/romcal/romcal/issues"
   },
-  "homepage": "https://github.com/pejulian/romcal#README",
+  "homepage": "https://github.com/romcal/romcal/blob/master/README.md",
   "dependencies": {
     "lodash": "^4.17.15",
     "moment": "^2.24.0",

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -1,5 +1,0 @@
-export default {
-  "sanctoral": {
-    "saintsCyrilMonkAndMethodiusBishop": "Slavic Missionaries Cyril and Methodius Day"
-  }
-};

--- a/src/locales/en-BO.js
+++ b/src/locales/en-BO.js
@@ -1,5 +1,0 @@
-export default {
-  "sanctoral": {
-    "saintPaulMikiAndCompanionsMartyrs": "Saints Felipe de Jesus, Paul Miki and Companions, Martyrs",
-  }
-};

--- a/src/locales/en-PH.js
+++ b/src/locales/en-PH.js
@@ -1,5 +1,0 @@
-export default {
-  "sanctoral": {
-    "saintPaulMikiAndCompanionsMartyrs": "Saints Pedro Bautista, Paul Miki and Companions, Martyrs",
-  }
-};

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -1,4 +1,3 @@
-import cs from './cs';
 import enBO from './en-BO';
 import enCA from './en-CA';
 import enPH from './en-PH';
@@ -9,7 +8,6 @@ import pl from './pl';
 import sk from './sk';
 
 export {
-  cs,
   enBO,
   enCA,
   enPH,

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -1,6 +1,4 @@
-import enBO from './en-BO';
 import enCA from './en-CA';
-import enPH from './en-PH';
 import en from './en';
 import fr from './fr';
 import it from './it';
@@ -8,9 +6,7 @@ import pl from './pl';
 import sk from './sk';
 
 export {
-  enBO,
   enCA,
-  enPH,
   en,
   fr,
   it,


### PR DESCRIPTION
- Bump romcal version in `package.json`;
- Fix Git URLs in `package.json`;
- Fix the link to `README.md`;
- Fix the casing of _Localizing celebration names_ in the TOC of the `README.md`.
- Add specific link names to sections in `HISTORY.md`;
- Add blank lines between headings and the following paragraph make the `HISTORY.md` be more in conformity with Markdown standard syntax;
- Fix indentation in `HISTORY.md` (change 4 spaces to 2 spaces);
- Remove `cs.js`, en-BO.js and en-PH.js as there is no localised keys in there;
- Add list of contributors to `package.json`.