### PR TITLE
Update package-lock to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "romcal",
-  "version": "1.3.0-rc2",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
@tukusejssirs oops we forgot to update the package-lock.js

This is minor, but as soon as it's merged, I'll publish a new version on npm.