### PR TITLE
Remove duplicate `saintsAndrewZoerardusAndBenedictHermits` key

### DIFF
--- a/src/calendars/slovakia.js
+++ b/src/calendars/slovakia.js
@@ -129,7 +129,7 @@ let dates = year => {
       }
     },
     {
-      "key": "saintsAndrewZoerardusAndBenedictHermits",
+      "key": "saintsAndrewZorardAndBenedictHermits",
       "type": Types.MEMORIAL,
       "moment": moment.utc({ year: year, month: 6, day: 17 }),
       "data": {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -637,7 +637,6 @@ export default {
     "saintRoseOfLima": "Saint Rose of Lima, Virgin",
     "saintRosePhilippineDuchesneVirgin": "Saint Rose Philippine Duchesne, Virgin",
     "saintsAlbanJuliusAndAaronMartyrs": "Saints Alban, Julius and Aaron, Martyrs",
-    "saintsAndrewZoerardusAndBenedictHermits": "Saints Andrew Zoerardus and Benedict, Hermits",
     "saintsAndrewZorardAndBenedictHermits": "Saints Andrew Zorard and Benedict, Hermits",
     "saintsAugustineZhaoRongPriestAndCompanionsMartyrs": "Saints Augustine Zhao Rong, Priest, and Companions, Martyrs",
     "saintsBasilTheGreatAndGregoryNazianzenBishopsAndDoctors": "Saints Basil the Great and Gregory Nazianzen, Bishops and Doctors",

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -253,6 +253,7 @@ export default {
     "saintRobertBellarmineBishopAndDoctor": "Saint Robert Bellarmin, Jésuite, Évêque et Docteur de l’Eglise (✝ 1621)",
     "saintRomualdAbbot": "Saint Romuald, Anachorète et Père des moines Camaldules (✝ 1027)",
     "saintRoseOfLima": "Sainte Rose de Lima, Vierge (✝ 1617)",
+    "saintsAndrewZorardAndBenedictHermits": "Saints André Svorad († 1009) et Benoît Stojislav († 1012), Ermites",
     "saintsAugustineZhaoRongPriestAndCompanionsMartyrs": "Saints Augustin Zhao Rong et ses compagnons, Martyrs en Chine (entre 1648 et 1930)",
     "saintsBasilTheGreatAndGregoryNazianzenBishopsAndDoctors": "Saints Basile le Grand (✝ 379) et Grégoire de Naziance (✝ 390), Évêques et Docteurs de l’Église",
     "saintsCharlesLwangaAndCompanionsMartyrs": "Saints Charles Lwanga et ses douze compagnons, Martyrs (✝ 618)",

--- a/src/locales/sk.js
+++ b/src/locales/sk.js
@@ -610,7 +610,6 @@ export default {
     "saintRoseOfLima": "Svätej Ruženy Limskej, panny",
     "saintRosePhilippineDuchesneVirgin": "Svätej Ruženy Filipíny Duchesne, panny",
     "saintsAlbanJuliusAndAaronMartyrs": "Svätého Albána, Júlia and Árona, mučeníkov",
-    "saintsAndrewZoerardusAndBenedictHermits": "Svätých Andreja-Svorada a Benedikta, pustovníkov",
     "saintsAndrewZorardAndBenedictHermits": "Svätých Andreja-Svorada a Benedikta, pustovníkov",
     "saintsAugustineZhaoRongPriestAndCompanionsMartyrs": "Svätých Augustína Zhao Rong, kňaza, a spoločníkov, mučeníkov",
     "saintsBasilTheGreatAndGregoryNazianzenBishopsAndDoctors": "Svätých Bazila Veľkého a Gregora Nazianzského, biskupov a učiteľov Cirkvi",


### PR DESCRIPTION
- Remove the key from `en.js` and `sk.js`;
- Rename the key in `slovakia.js` to `saintsAndrewZorardAndBenedictHermits`;
- Add French translation of the `saintsAndrewZorardAndBenedictHermits` key.