### PR TITLE
fix(france): preserve Saint Joseph Calasanz commons

### DIFF
--- a/rites/roman1969/src/calendars/countries/france/index.ts
+++ b/rites/roman1969/src/calendars/countries/france/index.ts
@@ -126,7 +126,6 @@ export class France extends CalendarDef {
     // src: mr_fr_2021_ed3
     joseph_of_calasanz_priest: {
       dateDef: { month: 8, date: 26 },
-      commonsDef: Common.Saints,
     },
 
     // src: mr_fr_2021_ed3


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR removes an incorrect French override for **Saint Joseph Calasanz**.

France only transfers the celebration from August 25 to August 26. Its commons remain those defined by the *Missale Romanum*: the Common of Educators or the Common of Pastors.


## Sources

- *Missel romain*, the third French-language edition of the Roman Missal (2021), Proper of France and Proper of Saints, p. 764
- *Missale Romanum*, editio typica tertia: “De Communi sanctorum: pro educatoribus, vel de Communi pastorum: pro uno pastore”
- [Official French-language Ordo supplement](https://www.cecc.ca/wp-content/uploads/2021/11/Ordo_2022_complementaire-VF.pdf)

---

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
