### PR TITLE
fix(switzerland): align calendar with the 2021 proper

### DIFF
--- a/rites/roman1969/src/calendars/countries/switzerland/index.ts
+++ b/rites/roman1969/src/calendars/countries/switzerland/index.ts
@@ -1,3 +1,4 @@
+import { PatronTitle } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
 import { Inputs } from '../../../types/calendar-def';
@@ -7,9 +8,14 @@ export class Switzerland extends CalendarDef {
   ParentCalendars = [Europe];
 
   inputs: Inputs = {
-    john_nepomucene_priest: {
-      precedence: Precedences.ProperMemorial_11b,
-      dateDef: { month: 5, date: 16 },
+    // src:
+    // - mr_fr_2021_ed3
+    // - https://www.bischoefe.ch/st-nikolaus-von-fluee-schutzpatron-der-sbk/
+    nicholas_of_flue_hermit: {
+      customLocaleId: 'nicholas_of_flue_hermit_patron_of_switzerland',
+      precedence: Precedences.ProperSolemnity_PrincipalPatron_4a,
+      dateDef: { month: 9, date: 25 },
+      titles: { append: [PatronTitle.PatronOfSwitzerland] },
     },
   };
 }

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -3372,10 +3372,12 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'John Neumann',
       titles: [Title.Bishop],
     },
+    // src: https://www.liturgie.ch/images/liturgie/praxis/dokumente/pdf/DBK_577.pdf
     john_nepomucene_priest: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'John Nepomucene',
       titles: [Title.Priest, Title.Martyr],
+      dateOfDeath: 1393,
     },
     john_of_avila_priest: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -4655,10 +4657,13 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Priest],
       dateOfDeath: '1686-5-31',
     },
+    // src: mr_fr_2021_ed3
     nicholas_of_flue_hermit: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Nicholas of Flüe',
       titles: [Title.Hermit],
+      dateOfBirth: 1417,
+      dateOfDeath: 1487,
     },
     nicholas_of_myra_bishop: {
       canonizationLevel: CanonizationLevels.Saint,

--- a/rites/roman1969/src/constants/martyrology-metadata.ts
+++ b/rites/roman1969/src/constants/martyrology-metadata.ts
@@ -92,6 +92,7 @@ export enum PatronTitle {
   PatronOfRussia = 'PATRON_OF_RUSSIA',
   PatronOfScotland = 'PATRON_OF_SCOTLAND',
   PatronOfSpain = 'PATRON_OF_SPAIN',
+  PatronOfSwitzerland = 'PATRON_OF_SWITZERLAND',
   PatronOfTheCzechNation = 'PATRON_OF_THE_CZECH_NATION',
   PatronOfTheDiocese = 'PATRON_OF_THE_DIOCESE',
   PatronOfWales = 'PATRON_OF_WALES',

--- a/rites/roman1969/src/locales/de.ts
+++ b/rites/roman1969/src/locales/de.ts
@@ -662,6 +662,7 @@ export const locale: Locale = {
     nicetius_of_lyon_bishop: 'Hl. Nizier, Bischof',
     nicholas_barre_priest: 'Sel. Nikolaus Barré, Priester',
     nicholas_of_flue_hermit: 'Hl. Niklaus von Flüe, Einsiedler',
+    nicholas_of_flue_hermit_patron_of_switzerland: 'Hl. Niklaus von Flüe, Einsiedler, Friedensstifter, Landespatron',
     nicholas_of_myra_bishop: 'Hl. Nikolaus, Bischof',
     nicholas_steno_bishop: 'Sel. Nikolaus Steno, Bischof',
     nicholas_tavelic_priest: 'Hl. Nikolaus Tavelić, Priester und Märtyrer',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -896,6 +896,8 @@ export const locale: Locale = {
     nicetius_of_lyon_bishop: 'Saint Nicetius, Bishop',
     nicholas_barre_priest: 'Blessed Nicholas Barré, Priest',
     nicholas_of_flue_hermit: 'Saint Nicholas of Flüe, Hermit',
+    nicholas_of_flue_hermit_patron_of_switzerland:
+      'Saint Nicholas of Flüe, Principal Patron of the Swiss Confederation',
     nicholas_of_myra_bishop: 'Saint Nicholas, Bishop',
     nicholas_steno_bishop: 'Blessed Nicholas Steno, Bishop',
     nicholas_tavelic_priest: 'Saint Nicholas Tavelić, Priest and Martyr',

--- a/rites/roman1969/src/locales/fr.ts
+++ b/rites/roman1969/src/locales/fr.ts
@@ -468,6 +468,7 @@ export const locale: Locale = {
     john_i_pope: 'Saint Jean Ier, pape et martyr († 526)',
     john_leonardi_priest: 'Saint Jean Léonardi, prêtre († 1609)',
     john_mary_vianney_priest: 'Saint Jean-Marie Vianney, prêtre, curé d’Ars († 1859)',
+    john_nepomucene_priest: 'Saint Jean Népomucène, prêtre et martyr († 1393)',
     john_of_avila_priest: 'Saint Jean d’Avila, prêtre et docteur de l’Église († 1569)',
     john_of_capistrano_priest: 'Saint Jean de Capistran, prêtre de l’Ordre des Mineurs († 1456)',
     john_of_god_duarte_cidade_religious: 'Saint Jean de Dieu, religieux, fondateur des Frères de la Charité († 1550)',
@@ -614,6 +615,9 @@ export const locale: Locale = {
     nereus_of_terracina_and_achilleus_of_terracina_martyrs: 'Saints Nérée et Achillée, martyrs à Rome († v. 304)',
     nicetius_of_lyon_bishop: 'Saint Nizier, évêque († 573)', // src: mr_fr_2014_ed2_lyon
     nicholas_barre_priest: 'Bienheureux. Nicolas Barré, prêtre († 1686 à Paris)',
+    nicholas_of_flue_hermit: 'Saint Nicolas de Flüe, ermite († 1487)', // src: mr_fr_2021_ed3
+    nicholas_of_flue_hermit_patron_of_switzerland:
+      'Saint Nicolas de Flüe, patron principal de la Confédération helvétique († 1487)', // src: mr_fr_2021_ed3
     nicholas_of_myra_bishop: 'Saint Nicolas, évêque de Myre († v. 350)',
     noel_pinot_priest: 'Bienheureux Noël Pinot, prêtre et martyr († 1794)', // mr_fr_2022_ed3_angers
     norbert_of_xanten_bishop: 'Saint Norbert, évêque († 1134)',


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR aligns the national calendar of Switzerland with the 2021 Swiss proper:

- adds Saint Nicholas of Flüe on September 25 as a solemnity and principal patron of the Swiss Confederation;
- removes Saint John Nepomucene from the nationwide calendar, as his celebration is limited to particular territories;
- retains Saint John Nepomucene in the martyrology for future local calendars;
- adds the related metadata and French, English and German localizations.

## Sources

- *Missel romain*, the third French-language edition of the Roman Missal (2021), Proper of Switzerland
- [Swiss Bishops’ Conference — Saint Nicholas of Flüe](https://www.bischoefe.ch/st-nikolaus-von-fluee-schutzpatron-der-sbk/)
- [Regional liturgical calendar concerning Saint John Nepomucene](https://www.liturgie.ch/images/liturgie/praxis/dokumente/pdf/DBK_577.pdf)

---

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
