### PR TITLE
fix(calendar): align England and Wales calendars

### DIFF
--- a/rites/roman1969/src/calendars/countries/england/index.ts
+++ b/rites/roman1969/src/calendars/countries/england/index.ts
@@ -1,12 +1,20 @@
+import { CommonDefinition as Common } from '../../../constants/commons';
 import { ProperCycles } from '../../../constants/cycles';
 import { PatronTitle } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
-import { Inputs } from '../../../types/calendar-def';
+import { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class England extends CalendarDef {
   ParentCalendars = [Europe];
+
+  // src: https://www.liturgyoffice.org.uk/Calendar/2027/Ordo-2027.pdf
+  particularConfig: ParticularConfig = {
+    epiphanyOnSunday: false,
+    ascensionOnSunday: false,
+    corpusChristiOnSunday: true,
+  };
 
   inputs: Inputs = {
     aelred_of_rievaulx_abbot: {
@@ -81,11 +89,6 @@ export class England extends CalendarDef {
       dateDef: { month: 6, date: 5 },
     },
 
-    ephrem_the_syrian_deacon: {
-      precedence: Precedences.OptionalMemorial_12,
-      dateDef: { month: 6, date: 9 },
-    },
-
     columba_of_iona_abbot: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 9 },
@@ -146,9 +149,12 @@ export class England extends CalendarDef {
       dateDef: { month: 9, date: 19 },
     },
 
+    // src: https://www.liturgyoffice.org.uk/Calendar/Sanctoral/September/Walsingham.pdf
     our_lady_of_walsingham: {
-      precedence: Precedences.ProperMemorial_11b,
+      // This celebration was a Memorial before the Holy See confirmed its elevation in 2024.
+      precedence: Precedences.ProperFeast_8f,
       dateDef: { month: 9, date: 24 },
+      commonsDef: Common.None,
     },
 
     john_henry_newman_priest: {

--- a/rites/roman1969/src/calendars/countries/wales/index.ts
+++ b/rites/roman1969/src/calendars/countries/wales/index.ts
@@ -2,11 +2,18 @@ import { ProperCycles } from '../../../constants/cycles';
 import { PatronTitle } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
-import { Inputs } from '../../../types/calendar-def';
+import { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Wales extends CalendarDef {
   ParentCalendars = [Europe];
+
+  // src: https://www.liturgyoffice.org.uk/Calendar/2027/Ordo-2027.pdf
+  particularConfig: ParticularConfig = {
+    epiphanyOnSunday: false,
+    ascensionOnSunday: false,
+    corpusChristiOnSunday: true,
+  };
 
   inputs: Inputs = {
     teilo_of_llandaff_bishop: {
@@ -42,9 +49,10 @@ export class Wales extends CalendarDef {
       dateDef: { month: 7, date: 12 },
     },
 
+    // src: https://www.liturgyoffice.org.uk/Calendar/National/Wales1.shtml
     philip_evans_and_john_lloyd_priests: {
       precedence: Precedences.OptionalMemorial_12,
-      dateDef: { month: 7, date: 25 },
+      dateDef: { month: 7, date: 23 },
       martyrology: ['philip_evans_priest', 'john_lloyd_priest'],
     },
 
@@ -65,7 +73,6 @@ export class Wales extends CalendarDef {
 
     john_henry_newman_priest: {
       precedence: Precedences.ProperFeast_8f,
-      dateDef: { month: 10, date: 9 },
     },
 
     denis_of_paris_bishop_and_companions_martyrs: {
@@ -119,9 +126,10 @@ export class Wales extends CalendarDef {
       },
     },
 
+    // src: https://www.liturgyoffice.org.uk/Calendar/National/Wales1.shtml
     all_saints_of_wales: {
       precedence: Precedences.ProperFeast_8f,
-      dateDef: { month: 11, date: 6 },
+      dateDef: { month: 11, date: 8 },
     },
 
     dyfrig_of_wales_bishop: {


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR aligns the national calendars of England and Wales with the latest official documents published by the Liturgy Office of the Catholic Bishops’ Conference of England and Wales.

## Changes

- Celebrates Corpus Christi on Sunday in England and Wales.
- Elevates Our Lady of Walsingham from Memorial to Feast, following the 2024 confirmation by the Holy See.
- Uses `Common.None` for Our Lady of Walsingham because a complete proper formulary is provided.
- Moves Saints Philip Evans and John Lloyd to 23 July in Wales.
- Moves All Saints of Wales to 8 November.
- Removes redundant local definitions already inherited from the General Roman Calendar.

## Sources

- [Calendar Notes for 2027](https://www.liturgyoffice.org.uk/Calendar/2027/Ordo-2027.pdf)
- [National Calendar for England](https://www.liturgyoffice.org.uk/Calendar/National/England1.shtml)
- [National Calendar for Wales](https://www.liturgyoffice.org.uk/Calendar/National/Wales1.shtml)
- [Our Lady of Walsingham — approved liturgical texts](https://www.liturgyoffice.org.uk/Calendar/Sanctoral/September/Walsingham.pdf)

The sources used here apply specifically to England and Wales. 

---

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).