### PR TITLE
feat(england.westminster): add Westminster calendar

### DIFF
--- a/docs/calendar-plugins.md
+++ b/docs/calendar-plugins.md
@@ -36,6 +36,7 @@ Below the list of all available calendar plugins:
 | Czech Republic             | `@romcal/calendar.czech-republic@dev`           |
 | Denmark                    | `@romcal/calendar.denmark@dev`                  |
 | England                    | `@romcal/calendar.england@dev`                  |
+| England / Westminster      | `@romcal/calendar.england.westminster@dev`      |
 | Europe                     | `@romcal/calendar.europe@dev`                   |
 | Finland                    | `@romcal/calendar.finland@dev`                  |
 | France                     | `@romcal/calendar.france@dev`                   |

--- a/rites/roman1969/src/calendars/countries/england/archdiocese-of-westminster.ts
+++ b/rites/roman1969/src/calendars/countries/england/archdiocese-of-westminster.ts
@@ -1,0 +1,101 @@
+import { CommonDefinition as Common } from '../../../constants/commons';
+import { PatronTitle } from '../../../constants/martyrology-metadata';
+import { Precedences } from '../../../constants/precedences';
+import { CalendarDef } from '../../../models/calendar-def';
+import type { Inputs } from '../../../types/calendar-def';
+import { Europe } from '../../regions/europe';
+
+import { England } from '.';
+
+export class England_Westminster extends CalendarDef {
+  ParentCalendars = [Europe, England];
+
+  inputs: Inputs = {
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    laurence_of_canterbury_dunstan_of_canterbury_and_theodore_of_canterbury_bishops: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 2, date: 3 },
+      martyrology: ['laurence_of_canterbury_bishop', 'dunstan_of_canterbury_bishop', 'theodore_of_canterbury_bishop'],
+      commonsDef: Common.None,
+    },
+
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    joseph_spouse_of_mary: {
+      titles: { append: [PatronTitle.PatronOfTheDiocese] },
+    },
+
+    // src:
+    // - https://rcdow.org.uk/liturgy/
+    // - https://rcdow.org.uk/wp-content/uploads/2025/03/april-19th-st-alphege.pdf
+    alphege_of_canterbury_bishop: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 4, date: 19 },
+      commonsDef: Common.None,
+    },
+
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    erkenwald_of_london_and_mellitus_of_canterbury_bishops: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 4, date: 24 },
+      martyrology: ['erkenwald_of_london_bishop', 'mellitus_of_canterbury_bishop'],
+      commonsDef: Common.None,
+    },
+
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    // Saint Dunstan is celebrated with Saints Laurence and Theodore on 3 February.
+    dunstan_of_canterbury_bishop: {
+      drop: true,
+    },
+
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    alban_of_britain_martyr: {
+      precedence: Precedences.ProperMemorial_11b,
+    },
+
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    // This celebration is a solemnity in Westminster Cathedral.
+    john_southworth_priest: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 6, date: 27 },
+      commonsDef: Common.None,
+    },
+
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    // This celebration is a solemnity in Westminster Cathedral.
+    dedication_of_westminster_cathedral_england: {
+      precedence: Precedences.ProperFeast_DedicationOfTheCathedralChurch_8b,
+      dateDef: { month: 7, date: 1 },
+      commonsDef: Common.DedicationAnniversary_Outside,
+    },
+
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    // Saint Theodore is celebrated with Saints Laurence and Dunstan on 3 February.
+    theodore_of_canterbury_bishop: {
+      drop: true,
+    },
+
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    // This celebration is a solemnity in the City of Westminster.
+    edward_the_confessor: {
+      precedence: Precedences.ProperFeast_PrincipalPatronOfADiocese_8a,
+      titles: { append: [PatronTitle.PatronOfTheDiocese] },
+    },
+
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    blessed_martyrs_of_douai: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 10, date: 29 },
+      commonsDef: Common.None,
+    },
+
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    edmund_of_abingdon_bishop: {
+      precedence: Precedences.ProperMemorial_11b,
+    },
+
+    // src: https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf
+    immaculate_conception_of_the_blessed_virgin_mary: {
+      titles: { append: [PatronTitle.PatronOfTheDiocese] },
+    },
+  };
+}

--- a/rites/roman1969/src/calendars/countries/england/index.ts
+++ b/rites/roman1969/src/calendars/countries/england/index.ts
@@ -6,6 +6,8 @@ import { CalendarDef } from '../../../models/calendar-def';
 import { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
+import { England_Westminster } from './archdiocese-of-westminster';
+
 export class England extends CalendarDef {
   ParentCalendars = [Europe];
 
@@ -295,3 +297,5 @@ export class England extends CalendarDef {
     },
   };
 }
+
+export { England_Westminster };

--- a/rites/roman1969/src/calendars/index.ts
+++ b/rites/roman1969/src/calendars/index.ts
@@ -14,7 +14,7 @@ import { CostaRica } from './countries/costa-rica';
 import { Croatia } from './countries/croatia';
 import { CzechRepublic } from './countries/czech-republic';
 import { Denmark } from './countries/denmark';
-import { England } from './countries/england';
+import { England, England_Westminster } from './countries/england';
 import { Finland } from './countries/finland';
 import {
   France,
@@ -104,6 +104,7 @@ export const calendarDefinitions: Record<string, typeof CalendarDef> = {
   CzechRepublic,
   Denmark,
   England,
+  England_Westminster,
   Europe,
   Finland,
   France,

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -358,6 +358,16 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Aloysius Versiglia',
       titles: [Title.Bishop, Title.Martyr],
     },
+    // src:
+    // - https://rcdow.org.uk/liturgy/
+    // - https://saintalphege.org.uk/history/
+    alphege_of_canterbury_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Alphege of Canterbury',
+      titles: [Title.Bishop, Title.Martyr],
+      dateOfBirth: { or: [953, 954] },
+      dateOfDeath: '1012-04-19',
+    },
     alphonsa_of_the_immaculate_conception_muttathupadathu_virgin: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Alphonsa of the Immaculate Conception Muttathupadathu',
@@ -1047,6 +1057,16 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
     blessed_martyrs_of_angers: {
       canonizationLevel: CanonizationLevels.Blessed,
       name: 'Martyrs of Angers',
+      count: 'many',
+      titles: [Title.Martyr],
+      hideTitles: true,
+    },
+    // src:
+    // - https://rcdow.org.uk/liturgy/
+    // - https://rcdow.org.uk/bishop-john-sherrington/homily-for-the-mass-of-acolytate/
+    blessed_martyrs_of_douai: {
+      canonizationLevel: CanonizationLevels.Blessed,
+      name: 'Martyrs of Douai',
       count: 'many',
       titles: [Title.Martyr],
       hideTitles: true,
@@ -1785,6 +1805,10 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
     dedication_of_the_lateran_basilica: {
       name: 'Dedication of the Lateran Basilica',
     },
+    // src: https://westminstercathedral.org.uk/the-cathedral/history-of-the-cathedral/
+    dedication_of_westminster_cathedral_england: {
+      dateOfDedication: '1910-06-28',
+    },
     deiniol_of_bangor_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Deiniol',
@@ -2049,6 +2073,15 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Eric IX of Sweden',
       titles: [Title.Martyr],
+    },
+    // src:
+    // - https://rcdow.org.uk/liturgy/
+    // - https://en.wikipedia.org/wiki/Earconwald
+    erkenwald_of_london_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Erkenwald of London',
+      titles: [Title.Bishop],
+      dateOfDeath: 693,
     },
     etheldreda_of_ely_abbess: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -3614,6 +3647,19 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'John Scheffler',
       titles: [Title.Bishop, Title.Martyr],
     },
+    // src:
+    // - https://rcdow.org.uk/liturgy/
+    // - https://rcdow.org.uk/news/st-john-southworth/
+    john_southworth_priest: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'John Southworth',
+      titles: [Title.Priest, Title.Martyr],
+      dateOfBirth: 1592,
+      dateOfBirthIsApproximative: true,
+      dateOfDeath: '1654-06-28',
+      dateOfBeatification: 1929,
+      dateOfCanonization: 1970,
+    },
     john_xxiii_pope: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'John XXIII',
@@ -3879,6 +3925,15 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       canonizationLevel: CanonizationLevels.Blessed,
       name: 'Laura Vicuña',
       titles: [Title.Virgin],
+    },
+    // src:
+    // - https://rcdow.org.uk/liturgy/
+    // - https://en.wikipedia.org/wiki/Laurence_of_Canterbury
+    laurence_of_canterbury_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Laurence of Canterbury',
+      titles: [Title.Bishop],
+      dateOfDeath: '619-02-02',
     },
     laurence_otoole_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -4697,6 +4752,15 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Melchior Grodziecki',
       titles: [Title.Priest, Title.Martyr],
+    },
+    // src:
+    // - https://rcdow.org.uk/liturgy/
+    // - https://www.newadvent.org/cathen/10168b.htm
+    mellitus_of_canterbury_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Mellitus of Canterbury',
+      titles: [Title.Bishop],
+      dateOfDeath: '624-04-24',
     },
     methodius_michael_of_thessaloniki_bishop: {
       canonizationLevel: CanonizationLevels.Saint,

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -97,6 +97,7 @@ export const locale: Locale = {
     aloysius_stepinac_bishop: 'Blessed Aloysius Stepinac, Bishop and Martyr',
     aloysius_versiglia_bishop_and_callistus_caravario_priest_martyrs:
       'Saints Aloysius Versiglia, Bishop and Callistus Caravario, Priest, Martyrs',
+    alphege_of_canterbury_bishop: 'Saint Alphege, Bishop and Martyr',
     alphonsa_of_the_immaculate_conception_muttathupadathu_virgin:
       'Saint Alphonsa of the Immaculate Conception Muttathupadathu, Virgin',
     alphonsus_mary_liguori_bishop: 'Saint Alphonsus Mary Liguori, Bishop and Doctor of the Church',
@@ -215,6 +216,7 @@ export const locale: Locale = {
     beuno_of_wales_abbot: 'Saint Beuno, Abbot',
     blaise_of_sebaste_bishop: 'Saint Blaise, Bishop and Martyr',
     blessed_martyrs_of_angers: 'Blessed Martyrs of Angers', // mr_fr_2022_ed3_angers
+    blessed_martyrs_of_douai: 'Blessed Martyrs of Douai',
     blessed_martyrs_of_paris: 'Blessed Martyrs of Paris',
     bogumilus_of_dobrow_bishop: 'Blessed Bogumilus, Bishop',
     boleslawa_mary_lament_virgin: 'Blessed Boleslawa Mary Lament, Virgin',
@@ -377,6 +379,7 @@ export const locale: Locale = {
     dedication_of_the_lateran_basilica: 'The Dedication of the Lateran Basilica',
     dedication_of_the_notre_dame_de_paris_cathedral_paris_france:
       'The Dedication of the Notre-Dame de Paris Cathedral, Paris',
+    dedication_of_westminster_cathedral_england: 'The Dedication of Westminster Cathedral',
     deiniol_of_bangor_bishop: 'Saint Deiniol, Bishop',
     demetrius_of_thessaloniki_martyr: 'Saint Demetrius of Thessaloniki, Martyr',
     denis_of_paris_bishop_and_companions_martyrs: 'Saint Denis, Bishop, and Companions, Martyrs',
@@ -429,6 +432,8 @@ export const locale: Locale = {
     epipodius_of_lyon_and_alexander_of_lyon_martyrs: 'Saints Epipodius and Alexander, Martyrs',
     erembert_of_toulouse_bishop: 'Saint Erembert of Toulouse, Bishop',
     eric_ix_of_sweden_martyr: 'Saint Eric IX of Sweden, Martyr',
+    erkenwald_of_london_and_mellitus_of_canterbury_bishops: 'Saints Erkenwald and Mellitus, Bishops',
+    erkenwald_of_london_bishop: 'Saint Erkenwald, Bishop',
     etheldreda_of_ely_abbess: 'Saint Etheldreda, Abbess',
     eucharistic_celebration_on_lunar_new_year_day: 'Eucharistic Celebration on Lunar New Year Day',
     eucharius_of_trier_bishop: 'Saint Eucharius, Bishop',
@@ -699,6 +704,7 @@ export const locale: Locale = {
     john_roberts_priest: 'Saint John Roberts, Priest and Martyr',
     john_sarkander_priest: 'Saint John Sarkander, Priest and Martyr',
     john_scheffler_bishop: 'Blessed John Scheffler, Bishop and Martyr',
+    john_southworth_priest: 'Saint John Southworth, Priest and Martyr',
     john_xxiii_pope: 'Saint John XXIII, Pope',
     josaphat_kuntsevych_bishop: 'Saint Josaphat, Bishop and Martyr',
     jose_maria_de_yermo_y_parres_priest: 'Saint José Maria de Yermo y Parres, Priest',
@@ -750,6 +756,9 @@ export const locale: Locale = {
     laud_of_coutances_bishop_patron_of_the_diocese_of_coutances:
       'Saint Laud, Bishop, Patron of the Diocese of Coutances',
     laura_vicuna_virgin: 'Blessed Laura Vicuña, Virgin',
+    laurence_of_canterbury_bishop: 'Saint Laurence of Canterbury, Bishop',
+    laurence_of_canterbury_dunstan_of_canterbury_and_theodore_of_canterbury_bishops:
+      'Saints Laurence, Dunstan and Theodore, Archbishops of Canterbury',
     laurence_otoole_bishop: 'Saint Laurence O’Toole, Bishop',
     laurence_wang_bing_and_companions_martyrs: 'Saint Laurence Wang Bing and Companions, Martyrs',
     lawrence_bai_xiaoman_martyr: 'Saint Lawrence Bai Xiaoman, Martyr',
@@ -889,6 +898,7 @@ export const locale: Locale = {
     meinrad_of_einsiedeln_martyr: 'Saint Meinrad of Einsiedeln, Martyr',
     mel_of_ardagh_bishop: 'Saint Mel, Bishop',
     melchior_grodziecki_priest: 'Saint Melchior Grodziecki, Priest and Martyr',
+    mellitus_of_canterbury_bishop: 'Saint Mellitus, Bishop',
     michael_gabriel_and_raphael_archangels: 'Saints Michael, Gabriel and Raphael, Archangels',
     michael_garicoits_priest: 'Saint Michael Garicoïts, Priest',
     michael_kozal_bishop: 'Blessed Michael Kozal, Bishop and Martyr',

--- a/rites/roman1969/src/locales/fr.ts
+++ b/rites/roman1969/src/locales/fr.ts
@@ -79,6 +79,7 @@ export const locale: Locale = {
     all_saints_of_the_diocese_of_nanterre: 'Tous les Saints du diocèse de Nanterre', // src: mr_fr_2009_ed2_paris_creteil_nanterre_saint_denis
     all_saints_of_the_diocese_of_saint_denis: 'Tous les Saints du diocèse de Saint-Denis',
     aloysius_gonzaga_religious: 'Saint Louis de Gonzague, religieux Jésuite († 1591)',
+    alphege_of_canterbury_bishop: 'Saint Alphège, évêque et martyr',
     alphonsus_mary_liguori_bishop: 'Saint Alphonse-Marie de Liguori, évêque et docteur de l’Église',
     alpinien: 'Saint Alpinien',
     amand_of_maastricht_bishop: 'Saint Amand d’Elnone, Missionnaire, évêque de Maastricht († v. 676)',
@@ -179,6 +180,7 @@ export const locale: Locale = {
     bertrand_of_comminges_bishop: 'Saint Bertrand de Comminges, évêque († 1126)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     blaise_of_sebaste_bishop: 'Saint Blaise de Sébaste, évêque et martyr († 316)',
     blessed_martyrs_of_angers: 'Bienheureux Martyrs d’Angers († 1793-1794)', // mr_fr_2022_ed3_angers
+    blessed_martyrs_of_douai: 'Bienheureux martyrs de Douai',
     blessed_martyrs_of_paris: 'Bienheureux Martyrs de Paris († du 2 au 6 septembre 1792)',
     bonaventure_of_bagnoregio_bishop: 'Saint Bonaventure, évêque d’Albano et docteur de l’Église († 1274)',
     boniface_of_mainz_bishop: 'Saint Boniface, évêque et martyr († 754)',
@@ -289,6 +291,7 @@ export const locale: Locale = {
     dedication_of_the_cathedral_of_the_holy_trinity_laval_france: 'Dédicace de la cathédrale de Laval', // src: mr_fr_1998_ed1_laval
     dedication_of_the_lateran_basilica: 'Dédicace de la Basilique du Latran',
     dedication_of_the_notre_dame_de_paris_cathedral_paris_france: 'Dédicace de la cathédrale de Paris',
+    dedication_of_westminster_cathedral_england: 'Dédicace de la cathédrale de Westminster',
     denis_of_paris_bishop_and_companions_martyrs:
       'Saint Denis, évêque, et ses compagnons, martyrs à Paris († IIIème s.)',
     denis_of_paris_bishop_patron_of_the_archdiocese_of_paris: 'Saint Denis, martyr, premier évêque, patron du diocèse',
@@ -324,6 +327,8 @@ export const locale: Locale = {
     epiphany_of_the_lord: 'Épiphanie du Seigneur',
     epipodius_of_lyon_and_alexander_of_lyon_martyrs: 'Saints Épipode et Alexandre, martyrs († 178)', // src: mr_fr_2014_ed2_lyon
     erembert_of_toulouse_bishop: 'Saint Érembert, évêque († v. 672)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
+    erkenwald_of_london_and_mellitus_of_canterbury_bishops: 'Saints Erkenwald et Mellitus, évêques',
+    erkenwald_of_london_bishop: 'Saint Erkenwald de Londres, évêque',
     eucharius_of_trier_bishop: 'Saint Euchaire, évêque († IVème s.)',
     eucherius_of_lyon_bishop: 'Saint Eucher, évêque († v. 449)', // src: mr_fr_2014_ed2_lyon
     eugene_de_mazenod_bishop:
@@ -502,6 +507,7 @@ export const locale: Locale = {
     john_of_kanty_priest: 'Saint Jean de Kenty, prêtre († 1473)',
     john_of_the_cross_priest: 'Saint Jean de la Croix, prêtre et docteur de l’Église († 1591)',
     john_paul_ii_pope: 'Saint Jean-Paul II, pape († 2005)',
+    john_southworth_priest: 'Saint John Southworth, prêtre et martyr',
     john_xxiii_pope: 'Saint Jean XXIII, pape († 1963)',
     josaphat_kuntsevych_bishop: 'Saint Josaphat Kuntsevych, évêque Basilien et martyr († 1623)',
     joseph_henri_chamayou_religious: 'Bienheureux Joseph-Henri Chamayou, religieux et martyr († 1936)', // src: https://albi.catholique.fr/wp-content/uploads/sites/24/2026/04/calendrier-liturgique-propre-du-diocese-dalbi.pdf
@@ -531,6 +537,9 @@ export const locale: Locale = {
     laud_of_coutances_bishop: 'Saint Lô, évêque de Coutances († 566)', // src: mr_fr_1982_ed2_coutances
     laud_of_coutances_bishop_patron_of_the_diocese_of_coutances:
       'Saint Lô, évêque de Coutances, patron du diocèse († 566)', // src: mr_fr_1982_ed2_coutances
+    laurence_of_canterbury_bishop: 'Saint Laurent de Cantorbéry, évêque',
+    laurence_of_canterbury_dunstan_of_canterbury_and_theodore_of_canterbury_bishops:
+      'Saints Laurent, Dunstan et Théodore, archevêques de Cantorbéry',
     lawrence_of_brindisi_priest: 'Saint Laurent de Brindisi, prêtre et docteur de l’Église († 1619)',
     lawrence_of_rome_deacon: 'Saint Laurent de Rome, diacre et martyr († 258)',
     lawrence_ruiz_and_companions_martyrs:
@@ -619,6 +628,7 @@ export const locale: Locale = {
     maximilian_mary_raymund_kolbe_priest: 'Saint Maximilien-Marie Kolbe, prêtre et martyr († 1941)',
     may_of_bodon_abbot: 'Saint May, abbé († v. 550)', // src: mr_fr_2016_ed1_gap_embrun
     mederic_of_autun_and_droctoveus_of_autun_abbots: 'Saint Merry et Saint Droctovée, Abbés',
+    mellitus_of_canterbury_bishop: 'Saint Mellitus de Cantorbéry, évêque',
     michael_gabriel_and_raphael_archangels: 'Saints Michel, Gabriel and Raphaël, archanges',
     michael_garicoits_priest: 'Saint Michel Garicoïts, prêtre († 1863)',
     misselin_of_tarbes_priest: 'Saint Misselin, prêtre († Ve s.)',


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR adds the proper calendar of the **Archdiocese of Westminster** in England.

The 2026 Ordo was cross-checked against the 2024 and 2025 editions to identify celebrations impeded in a particular year.

## Sources

- [Westminster Ordo 2026](https://rcdow.org.uk/wp-content/uploads/2026/05/Ordo-2026.pdf)
- [Westminster Ordo 2025](https://rcdow.org.uk/wp-content/uploads/2025/03/2025-ordo-with-cover.pdf)
- [Westminster Ordo 2024](https://web.archive.org/web/20240624053706id_/https://rcdow.org.uk/att/files/liturgical%20calendar/liturgical%20calendar%202024.pdf)
- [Westminster Diocesan Supplement](https://web.archive.org/web/20260414173727/https://rcdow.org.uk/liturgy/diocesan-supplement/)

---

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).