### PR TITLE
feat(england.arundel-brighton): add diocesan calendar

### DIFF
--- a/docs/calendar-plugins.md
+++ b/docs/calendar-plugins.md
@@ -41,6 +41,7 @@ Below the list of all available calendar plugins:
 | Czech Republic                        | `@romcal/calendar.czech-republic@dev`                      |
 | Denmark                               | `@romcal/calendar.denmark@dev`                             |
 | England                               | `@romcal/calendar.england@dev`                             |
+| England / Arundel Brighton            | `@romcal/calendar.england.arundel-brighton@dev`            |
 | England / Westminster                 | `@romcal/calendar.england.westminster@dev`                 |
 | Europe                                | `@romcal/calendar.europe@dev`                              |
 | Finland                               | `@romcal/calendar.finland@dev`                             |

--- a/rites/roman1969/src/calendars/countries/england/diocese-of-arundel-and-brighton.ts
+++ b/rites/roman1969/src/calendars/countries/england/diocese-of-arundel-and-brighton.ts
@@ -1,0 +1,101 @@
+import { CommonDefinition as Common } from '../../../constants/commons';
+import { PatronTitle } from '../../../constants/martyrology-metadata';
+import { Precedences } from '../../../constants/precedences';
+import { CalendarDef } from '../../../models/calendar-def';
+import type { Inputs } from '../../../types/calendar-def';
+import { Europe } from '../../regions/europe';
+
+import { England } from '.';
+
+export class England_ArundelBrighton extends CalendarDef {
+  ParentCalendars = [Europe, England];
+
+  inputs: Inputs = {
+    // src: https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    robert_southwell_priest: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 2, date: 21 },
+      commonsDef: Common.Martyrs,
+    },
+
+    // src: https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    carthusian_martyrs: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 5, date: 12 },
+      commonsDef: Common.Martyrs,
+    },
+
+    // src: https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    erkenwald_of_london_bishop: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 5, date: 13 },
+      commonsDef: Common.Bishops,
+    },
+
+    // src: https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    richard_of_chichester_bishop: {
+      customLocaleId: 'richard_of_chichester_bishop_secondary_patron_of_the_diocese_of_arundel_and_brighton',
+      precedence: Precedences.ProperMemorial_SecondPatron_11a,
+      titles: { append: [PatronTitle.SecondPatronOfTheDiocese] },
+      commonsDef: Common.Bishops,
+    },
+
+    // src: https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    thomas_garnet_priest: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 6, date: 23 },
+      commonsDef: Common.Martyrs,
+    },
+
+    // src:
+    // - https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    // - https://www.abdiocese.org.uk/diocese/arundel-cathedral
+    // This celebration is a solemnity in Arundel Cathedral.
+    dedication_of_arundel_cathedral_england: {
+      precedence: Precedences.ProperFeast_DedicationOfTheCathedralChurch_8b,
+      dateDef: { month: 7, date: 1 },
+      commonsDef: Common.DedicationAnniversary_Outside,
+    },
+
+    // src: https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    // Transferred from 1 July because of the anniversary of the dedication of Arundel Cathedral.
+    oliver_plunket_bishop: {
+      dateDef: { month: 7, date: 2 },
+    },
+
+    // src: https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    assumption_of_the_blessed_virgin_mary: {
+      customLocaleId: 'assumption_of_the_blessed_virgin_mary_copatroness_of_the_diocese_of_arundel_and_brighton',
+      titles: { append: [PatronTitle.CopatronessOfTheDiocese] },
+    },
+
+    // Earlier diocesan calendars observed this celebration as a memorial.
+    // src:
+    // - https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    // - https://arundelcathedral.uk/wp-content/uploads/2022/09/Newsletter-25-09-2022-02-10-2022.pdf
+    blessed_martyrs_of_sussex: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 10, date: 3 },
+      commonsDef: Common.None,
+    },
+
+    // src: https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    wilfrid_of_york_bishop: {
+      customLocaleId: 'wilfrid_of_york_bishop_secondary_patron_of_the_diocese_of_arundel_and_brighton',
+      precedence: Precedences.ProperMemorial_SecondPatron_11a,
+      titles: { append: [PatronTitle.SecondPatronOfTheDiocese] },
+      commonsDef: [Common.Bishops, Common.Missionaries],
+    },
+
+    // src:
+    // - https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    // - https://www.abdiocese.org.uk/diocese/arundel-cathedral
+    philip_howard_martyr: {
+      customLocaleId: 'philip_howard_martyr_patron_of_the_diocese_of_arundel_and_brighton',
+      precedence: Precedences.ProperSolemnity_PrincipalPatron_4a,
+      dateDef: { month: 10, date: 19 },
+      titles: { append: [PatronTitle.PatronOfTheDiocese] },
+      commonsDef: Common.Martyrs,
+    },
+  };
+}

--- a/rites/roman1969/src/calendars/countries/england/index.ts
+++ b/rites/roman1969/src/calendars/countries/england/index.ts
@@ -7,6 +7,7 @@ import { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 import { England_Westminster } from './archdiocese-of-westminster';
+import { England_ArundelBrighton } from './diocese-of-arundel-and-brighton';
 
 export class England extends CalendarDef {
   ParentCalendars = [Europe];
@@ -298,4 +299,4 @@ export class England extends CalendarDef {
   };
 }
 
-export { England_Westminster };
+export { England_ArundelBrighton, England_Westminster };

--- a/rites/roman1969/src/calendars/index.ts
+++ b/rites/roman1969/src/calendars/index.ts
@@ -15,7 +15,7 @@ import { CostaRica } from './countries/costa-rica';
 import { Croatia } from './countries/croatia';
 import { CzechRepublic } from './countries/czech-republic';
 import { Denmark } from './countries/denmark';
-import { England, England_Westminster } from './countries/england';
+import { England, England_ArundelBrighton, England_Westminster } from './countries/england';
 import { Finland } from './countries/finland';
 import {
   France,
@@ -119,6 +119,7 @@ export const calendarDefinitions: Record<string, typeof CalendarDef> = {
   CzechRepublic,
   Denmark,
   England,
+  England_ArundelBrighton,
   England_Westminster,
   Europe,
   Finland,

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -1184,6 +1184,16 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       hideTitles: true,
     },
     // src:
+    // - https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    // - https://universalis.com/20261003/today.htm
+    blessed_martyrs_of_sussex: {
+      canonizationLevel: CanonizationLevels.Blessed,
+      name: 'Martyrs of Sussex',
+      count: 10,
+      titles: [Title.Martyr],
+      hideTitles: true,
+    },
+    // src:
     // - mr_fr_1984_ed1_nimes
     // - https://www.nimes-catholique.fr/wp-content/uploads/2025/05/32-bienheureuses-martyres-dorange-livret-mai-2025.pdf
     // - https://www.canonisation-32-martyres-orange.fr/
@@ -1346,6 +1356,15 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Carthage',
       titles: [Title.Bishop],
+    },
+    // src:
+    // - https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    // - https://en.wikipedia.org/wiki/Carthusian_Martyrs_of_London
+    carthusian_martyrs: {
+      name: 'Carthusian Martyrs',
+      count: 18,
+      titles: [Title.Martyr],
+      hideTitles: true,
     },
     casimir_of_poland: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -1862,6 +1881,14 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Dedication of the Cathedral of Tunis, Tunisia',
     },
     // src:
+    // - https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
+    // - https://www.abdiocese.org.uk/diocese/arundel-cathedral
+    // - https://universalis.com/Europe.England.Arundel/20270701/today.htm
+    // The diocesan anniversary remains on the date of the church's opening, 1 July 1873.
+    dedication_of_arundel_cathedral_england: {
+      dateOfDedication: '1952-05-14',
+    },
+    // src:
     // - mr_fr_2021_ed3
     // - https://sip.gouvernement.lu/dam-assets/publications/bulletin/1963/BID_1963_17/BID_1963_17.pdf
     dedication_of_notre_dame_cathedral_luxembourg: {
@@ -2296,6 +2323,7 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
     },
     // src:
     // - https://rcdow.org.uk/liturgy/
+    // - https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf
     // - https://en.wikipedia.org/wiki/Earconwald
     erkenwald_of_london_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -6160,6 +6188,18 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Philip Evans',
       titles: [Title.Priest, Title.Martyr],
     },
+    // src:
+    // - https://www.abdiocese.org.uk/diocese/arundel-cathedral
+    // - https://en.wikipedia.org/wiki/Philip_Howard,_13th_Earl_of_Arundel
+    philip_howard_martyr: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Philip Howard',
+      titles: [Title.Martyr],
+      dateOfBirth: '1557-06-28',
+      dateOfDeath: '1595-10-19',
+      dateOfBeatification: '1929-12-15',
+      dateOfCanonization: '1970-10-25',
+    },
     philip_neri_priest: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Philip Neri',
@@ -6532,6 +6572,19 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Robert of Turlande',
       titles: [Title.Abbot],
       dateOfDeath: '1067-04-17',
+    },
+    // src:
+    // - https://www.jesuits.global/saint-blessed/saint-robert-southwell/
+    // - https://en.wikipedia.org/wiki/Robert_Southwell_(priest)
+    robert_southwell_priest: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Robert Southwell',
+      titles: [Title.Priest, Title.Martyr],
+      dateOfBirth: 1561,
+      dateOfBirthIsApproximative: true,
+      dateOfDeath: '1595-02-21',
+      dateOfBeatification: '1929-12-15',
+      dateOfCanonization: '1970-10-25',
     },
     roch_gonzalez_priest: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -7043,6 +7096,19 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
         or: ['1118-12-21', '1120-12-21'],
       },
       dateOfDeath: '1170-12-29',
+    },
+    // src:
+    // - https://www.jesuits.global/saint-blessed/saint-thomas-garnet/
+    // - https://en.wikipedia.org/wiki/Thomas_Garnet
+    thomas_garnet_priest: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Thomas Garnet',
+      titles: [Title.Priest, Title.Martyr],
+      dateOfBirth: 1575,
+      dateOfBirthIsApproximative: true,
+      dateOfDeath: '1608-06-23',
+      dateOfBeatification: '1929-12-15',
+      dateOfCanonization: '1970-10-25',
     },
     // src:
     // - mr_fr_1982_ed2_coutances

--- a/rites/roman1969/src/constants/martyrology-metadata.ts
+++ b/rites/roman1969/src/constants/martyrology-metadata.ts
@@ -83,6 +83,7 @@ export enum PatronTitle {
   CopatronessOfIreland = 'COPATRONESS_OF_IRELAND',
   CopatronessOfItalyAndEurope = 'COPATRONESS_OF_ITALY_AND_EUROPE',
   CopatronessOfThePhilippines = 'COPATRONESS_OF_THE_PHILIPPINES',
+  CopatronessOfTheDiocese = 'COPATRONESS_OF_THE_DIOCESE',
   PatronOfBelgium = 'PATRON_OF_BELGIUM',
   PatronOfCanada = 'PATRON_OF_CANADA',
   PatronOfEngland = 'PATRON_OF_ENGLAND',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -181,6 +181,8 @@ export const locale: Locale = {
     ash_wednesday: 'Ash Wednesday',
     asicus_of_elphin_bishop: 'Saint Asicus, Bishop',
     assumption_of_the_blessed_virgin_mary: 'The Assumption of the Blessed Virgin Mary',
+    assumption_of_the_blessed_virgin_mary_copatroness_of_the_diocese_of_arundel_and_brighton:
+      'The Assumption of the Blessed Virgin Mary, Co-Patroness of the Diocese of Arundel and Brighton',
     assumption_of_the_blessed_virgin_mary_patroness_of_france:
       'The Assumption of the Blessed Virgin Mary, Patroness of France',
     assumption_of_the_blessed_virgin_mary_patroness_of_france_and_principal_patroness_of_the_diocese_of_montauban:
@@ -243,6 +245,7 @@ export const locale: Locale = {
     blessed_martyrs_of_angers: 'Blessed Martyrs of Angers', // mr_fr_2022_ed3_angers
     blessed_martyrs_of_douai: 'Blessed Martyrs of Douai',
     blessed_martyrs_of_paris: 'Blessed Martyrs of Paris',
+    blessed_martyrs_of_sussex: 'Blessed Martyrs of Sussex',
     blessed_martyrs_of_the_french_revolution: 'Blessed Martyrs of the French Revolution',
     blessed_religious_martyrs_of_orange: 'Blessed Religious Martyrs of Orange', // src: mr_fr_1984_ed1_nimes
     bogumilus_of_dobrow_bishop: 'Blessed Bogumilus, Bishop',
@@ -275,6 +278,7 @@ export const locale: Locale = {
     carmelites_of_compiegne_virgins_and_martyrs: 'Saint Teresa of Saint Augustine and Companions, Virgins and Martyrs',
     caroline_kozka_virgin: 'Blessed Caroline Kózka, Virgin and Martyr',
     carthage_of_lismore_bishop: 'Saint Carthage, Bishop',
+    carthusian_martyrs: 'The Carthusian Martyrs',
     casimir_of_poland: 'Saint Casimir',
     castor_of_apt_bishop: 'Saint Castor of Apt, Bishop', // src: mr_fr_1984_ed1_nimes
     catherine_jarrige_virgin: 'Blessed Catherine Jarrige, Virgin',
@@ -371,6 +375,7 @@ export const locale: Locale = {
     day_of_prayer_for_the_legal_protection_of_unborn_children:
       'Day of Prayer for the Legal Protection of Unborn Children', // src: mr_en_2011_ed3_us
     declan_of_ardmore_bishop: 'Saint Declan, Bishop',
+    dedication_of_arundel_cathedral_england: 'The Dedication of Arundel Cathedral',
     dedication_of_consecrated_churches: 'The Dedication of Consecrated Churches Whose Date of Consecration is Unknown',
     dedication_of_notre_dame_cathedral_luxembourg: 'Dedication of Notre-Dame Cathedral, Luxembourg',
     dedication_of_the_basilica_of_mont_saint_michel_france:
@@ -1197,6 +1202,9 @@ export const locale: Locale = {
     peter_wu_guosheng_martyr: 'Saint Peter Wu Guosheng, Martyr',
     philip_and_james_apostles: 'Saints Philip and James, Apostles',
     philip_evans_and_john_lloyd_priests: 'Saints Philip Evans and John Lloyd, Priests and Martyrs',
+    philip_howard_martyr: 'Saint Philip Howard, Martyr',
+    philip_howard_martyr_patron_of_the_diocese_of_arundel_and_brighton:
+      'Saint Philip Howard, Martyr and Patron of the Diocese of Arundel and Brighton',
     philip_neri_priest: 'Saint Philip Neri, Priest',
     philip_of_jesus_de_las_casas_martyr: 'Saint Philip of Jesus de las Casas, Martyr',
     philip_of_jesus_de_las_casas_paul_miki_and_companions_martyrs:
@@ -1256,11 +1264,14 @@ export const locale: Locale = {
     rene_goupil_religious: 'Saint René Goupil, Religious and Martyr', // mr_fr_2022_ed3_angers
     richard_gwyn_martyr: 'Saint Richard Gwyn, Martyr',
     richard_of_chichester_bishop: 'Saint Richard of Chichester, Bishop',
+    richard_of_chichester_bishop_secondary_patron_of_the_diocese_of_arundel_and_brighton:
+      'Saint Richard of Chichester, Bishop and Secondary Patron of the Diocese of Arundel and Brighton',
     richardis_of_swabia_empress: 'Saint Richardis, Empress',
     rita_of_cascia_religious: 'Saint Rita of Cascia, Religious',
     robert_bellarmine_bishop: 'Saint Robert Bellarmine, Bishop and Doctor of the Church',
     robert_of_arbrissel_priest: 'Blessed Robert of Arbrissel, Priest and Hermit', // src: mr_fr_1998_ed1_laval
     robert_of_turlande_abbot: 'Saint Robert of Turlande, Abbot',
+    robert_southwell_priest: 'Saint Robert Southwell, Priest and Martyr',
     roch_gonzalez_alphonsus_rodriguez_and_john_del_castillo_priests:
       'Saints Roch González, Alphonsus Rodríguez and John del Castillo, Priests and Martyrs',
     roch_of_montpellier: 'Saint Roch, Pilgrim', // src: mr_fr_1974_ed1_region_apostolique_du_midi, mr_fr_1984_ed1_nimes
@@ -1354,6 +1365,7 @@ export const locale: Locale = {
     thomas_becket_bishop: 'Saint Thomas Becket, Bishop and Martyr',
     thomas_dubuisson_and_louis_lanier_priests_martyrs:
       'Blesseds Thomas Dubuisson and Louis Lanier, Priests and Martyrs', // src: mr_fr_1998_ed1_laval
+    thomas_garnet_priest: 'Saint Thomas Garnet, Priest and Martyr',
     thomas_helye_priest: 'Blessed Thomas Hélye, Priest',
     thomas_hioji_rokuzayemon_nishi_priest_and_companions_martyrs:
       'Saint Thomas Hioji Rokuzayemon Nishi, Priest, and Companions, Martyrs',
@@ -1411,6 +1423,8 @@ export const locale: Locale = {
     wenceslaus_i_of_bohemia_martyr_patron_of_the_czech_nation: 'Saint Wenceslaus, Martyr, Patron of the Czech nation',
     wendelin_of_trier_hermit: 'Saint Wendelin, Hermit',
     wilfrid_of_york_bishop: 'Saint Wilfrid, Bishop',
+    wilfrid_of_york_bishop_secondary_patron_of_the_diocese_of_arundel_and_brighton:
+      'Saint Wilfrid, Bishop and Secondary Patron of the Diocese of Arundel and Brighton',
     william_apor_bishop: 'Blessed William Apor, Bishop and Martyr',
     william_firmatus_abbot: 'Saint William Firmatus, Abbot',
     william_firmatus_robert_of_arbrissel_bernard_of_tiron_raoul_de_la_futaie_and_vitalis_of_savigny_hermits:

--- a/rites/roman1969/src/locales/fr.ts
+++ b/rites/roman1969/src/locales/fr.ts
@@ -153,6 +153,8 @@ export const locale: Locale = {
     ascension_of_the_lord: 'Ascension du Seigneur',
     ash_wednesday: 'Mercredi des Cendres',
     assumption_of_the_blessed_virgin_mary: 'Assomption de la bienheureuse Vierge Marie',
+    assumption_of_the_blessed_virgin_mary_copatroness_of_the_diocese_of_arundel_and_brighton:
+      'Assomption de la bienheureuse Vierge Marie, copatronne du diocèse d’Arundel et Brighton',
     assumption_of_the_blessed_virgin_mary_patroness_of_france:
       'Assomption de la bienheureuse Vierge Marie, patronne principale de la France',
     assumption_of_the_blessed_virgin_mary_patroness_of_france_and_principal_patroness_of_the_diocese_of_montauban:
@@ -208,6 +210,7 @@ export const locale: Locale = {
     blessed_martyrs_of_angers: 'Bienheureux Martyrs d’Angers († 1793-1794)', // mr_fr_2022_ed3_angers
     blessed_martyrs_of_douai: 'Bienheureux martyrs de Douai',
     blessed_martyrs_of_paris: 'Bienheureux Martyrs de Paris († du 2 au 6 septembre 1792)',
+    blessed_martyrs_of_sussex: 'Bienheureux Martyrs du Sussex',
     blessed_martyrs_of_the_french_revolution: 'Bienheureux martyrs de la Révolution',
     blessed_religious_martyrs_of_orange: 'Les Bienheureuses religieuses martyres d’Orange', // src: mr_fr_1984_ed1_nimes
     bonaventure_of_bagnoregio_bishop: 'Saint Bonaventure, évêque d’Albano et docteur de l’Église († 1274)',
@@ -230,6 +233,7 @@ export const locale: Locale = {
     // src: https://press.vatican.va/content/salastampa/en/bollettino/pubblico/2024/12/18/241218d.html
     carmelites_of_compiegne_virgins_and_martyrs:
       'Sainte Thérèse de Saint-Augustin et ses 15 compagnes, vierges et martyres († guillotinées en 1794)',
+    carthusian_martyrs: 'Les Martyrs chartreux',
     casimir_of_poland: 'Saint Casimir († 1484)',
     castor_of_apt_bishop: 'Saint Castor, évêque', // src: mr_fr_1984_ed1_nimes
     catherine_jarrige_virgin: 'Bienheureuse Catherine Jarrige, vierge († 1836)',
@@ -297,6 +301,7 @@ export const locale: Locale = {
     daniel_brottier_priest: 'Bienheureux Daniel Brottier, prêtre, apôtre des Orphelins d’Auteuil († 1936 à Paris)',
     day_of_prayer_for_the_legal_protection_of_unborn_children:
       'Journée de prière pour la protection juridique des enfants à naître',
+    dedication_of_arundel_cathedral_england: 'Dédicace de la cathédrale d’Arundel',
     dedication_of_consecrated_churches:
       'Dédicace des églises consacrées dont on ne connaît pas la date de consécration', // src: mr_fr_2021_ed3
     dedication_of_notre_dame_cathedral_luxembourg: 'Dédicace de la cathédrale Notre-Dame de Luxembourg', // src: mr_fr_2021_ed3
@@ -378,7 +383,7 @@ export const locale: Locale = {
     epipodius_of_lyon_and_alexander_of_lyon_martyrs: 'Saints Épipode et Alexandre, martyrs († 178)', // src: mr_fr_2014_ed2_lyon
     erembert_of_toulouse_bishop: 'Saint Érembert, évêque († v. 672)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     erkenwald_of_london_and_mellitus_of_canterbury_bishops: 'Saints Erkenwald et Mellitus, évêques',
-    erkenwald_of_london_bishop: 'Saint Erkenwald de Londres, évêque',
+    erkenwald_of_london_bishop: 'Saint Erkenwald de Londres, évêque († 693)',
     eucharius_of_trier_bishop: 'Saint Euchaire, évêque († IVème s.)',
     eucherius_of_lyon_bishop: 'Saint Eucher, évêque († v. 449)', // src: mr_fr_2014_ed2_lyon
     eugene_de_mazenod_bishop:
@@ -866,6 +871,9 @@ export const locale: Locale = {
     peter_of_castelnau_priest: 'Bienheureux Pierre de Castelnau, prêtre et martyr († 1208)',
     peter_of_luxembourg_bishop: 'Bienheureux Pierre de Luxembourg, évêque', // src: mr_fr_1984_ed1_nimes
     philip_and_james_apostles: 'Saint Philippe et Saint Jacques le Mineur, apôtres',
+    philip_howard_martyr: 'Saint Philippe Howard, martyr († 1595)',
+    philip_howard_martyr_patron_of_the_diocese_of_arundel_and_brighton:
+      'Saint Philippe Howard, martyr et patron du diocèse d’Arundel et Brighton († 1595)',
     philip_neri_priest: 'Saint Philippe Néri, prêtre († 1595)',
     phoebadius_of_agen_bishop: 'Saint Phébade, évêque',
     piatus_of_seclin_martyr: 'Saint Piat, missionnaire et martyr (IIIe s.)',
@@ -911,11 +919,14 @@ export const locale: Locale = {
     remigius_of_reims_bishop: 'Saint Remi, évêque de Reims († 530)',
     remy_isore_priest: 'Saint Rémy Isoré, prêtre et martyr († 1900)',
     rene_goupil_religious: 'Saint René Goupil, religieux et martyr († 1642)', // mr_fr_2022_ed3_angers
+    richard_of_chichester_bishop_secondary_patron_of_the_diocese_of_arundel_and_brighton:
+      'Saint Richard de Chichester, évêque et patron secondaire du diocèse d’Arundel et Brighton',
     richardis_of_swabia_empress: 'Sainte Richarde, impératrice († 894 ou 896)',
     rita_of_cascia_religious: 'Sainte Rita da Cascia, veuve puis religieuse († 1456)',
     robert_bellarmine_bishop: 'Saint Robert Bellarmin, Jésuite, évêque et docteur de l’Église († 1621)',
     robert_of_arbrissel_priest: 'Bienheureux Robert d’Arbrissel, prêtre et ermite († 1116)', // src: mr_fr_1998_ed1_laval
     robert_of_turlande_abbot: 'Saint Robert de Turlande, abbé († 1067)',
+    robert_southwell_priest: 'Saint Robert Southwell, prêtre et martyr († 1595)',
     roch_of_montpellier: 'Saint Roch, pèlerin († v. 1379)', // src: mr_fr_1974_ed1_region_apostolique_du_midi, mr_fr_1984_ed1_nimes
     romanus_ostiarius_martyr: 'Saint Roman, martyr († 258)', // src: mr_fr_2021_ed3
     romuald_of_ravenna_abbot: 'Saint Romuald, anachorète et père des moines Camaldules († 1027)',
@@ -975,6 +986,7 @@ export const locale: Locale = {
     thomas_aquinas_priest: 'Saint Thomas d’Aquin, prêtre et docteur de l’Église († 1274)', // src: mr_fr_2021_ed3, mr_fr_1974_ed1_region_apostolique_du_midi
     thomas_becket_bishop: 'Saint Thomas Becket, évêque et martyr († 1170)',
     thomas_dubuisson_and_louis_lanier_priests_martyrs: 'Bienheureux Thomas Dubuisson et Louis Lanier, prêtres, martyrs', // src: mr_fr_1998_ed1_laval
+    thomas_garnet_priest: 'Saint Thomas Garnet, prêtre et martyr († 1608)',
     thomas_helye_priest: 'Bienheureux Thomas Hélye, prêtre († 1257)', // src: mr_fr_1982_ed2_coutances
     thomas_jean_georges_rehm_priest: 'Bienheureux Jean-Georges Rehm, prêtre et martyr († 1794)',
     thomas_rene_dubuisson_priest_martyr: 'Bienheureux Thomas-René Dubuisson, prêtre et martyr († 1792)', // src: mr_fr_1998_ed1_laval
@@ -1017,6 +1029,8 @@ export const locale: Locale = {
     wenceslaus_i_of_bohemia_martyr_patron_of_the_czech_nation:
       'Saint Venceslas, martyr et patron de la nation tchèque († 929)',
     wendelin_of_trier_hermit: 'Saint Wendelin, ermite',
+    wilfrid_of_york_bishop_secondary_patron_of_the_diocese_of_arundel_and_brighton:
+      'Saint Wilfrid, évêque et patron secondaire du diocèse d’Arundel et Brighton',
     william_firmatus_abbot: 'Saint Guillaume Firmat, abbé († 1103)', // src: mr_fr_1982_ed2_coutances
     william_firmatus_robert_of_arbrissel_bernard_of_tiron_raoul_de_la_futaie_and_vitalis_of_savigny_hermits:
       'Saints Guillaume Firmat, Bernard de Tiron et Vital de Mortain, et les bienheureux Robert d’Arbrissel et Raoul de la Futaie, ermites', // src: mr_fr_1998_ed1_laval


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR adds the proper calendar of the **Diocese of Arundel and Brighton**, based on its official 2026 liturgical Ordo.

## Sources

- [Diocese of Arundel and Brighton — 2026 liturgical Ordo](https://cdn.prod.website-files.com/5ed93a8802f9816a9341c2a2/690c6cb4519d8389bb813f7f_Ordo%202026.pdf)
- [Diocese of Arundel and Brighton — Arundel Cathedral](https://www.abdiocese.org.uk/diocese/arundel-cathedral)
- [Society of Jesus — Saint Robert Southwell](https://www.jesuits.global/saint-blessed/saint-robert-southwell/)
- [Society of Jesus — Saint Thomas Garnet](https://www.jesuits.global/saint-blessed/saint-thomas-garnet/)

---

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).