### PR TITLE
feat(canada): align proper calendar and add Quebec

### DIFF
--- a/docs/calendar-plugins.md
+++ b/docs/calendar-plugins.md
@@ -29,6 +29,7 @@ Below the list of all available calendar plugins:
 | Bosnia Herzegovina         | `@romcal/calendar.bosnia-herzegovina@dev`       |
 | Brazil                     | `@romcal/calendar.brazil@dev`                   |
 | Canada                     | `@romcal/calendar.canada@dev`                   |
+| Canada / Quebec            | `@romcal/calendar.canada.quebec@dev`            |
 | Chile                      | `@romcal/calendar.chile@dev`                    |
 | China                      | `@romcal/calendar.china@dev`                    |
 | Costa Rica                 | `@romcal/calendar.costa-rica@dev`               |

--- a/rites/roman1969/src/calendars/countries/canada/index.ts
+++ b/rites/roman1969/src/calendars/countries/canada/index.ts
@@ -5,6 +5,8 @@ import { CalendarDef } from '../../../models/calendar-def';
 import { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
+import { Canada_Quebec } from './quebec';
+
 export class Canada extends CalendarDef {
   ParentCalendars = [Americas];
 
@@ -74,7 +76,10 @@ export class Canada extends CalendarDef {
       dateDef: { month: 5, date: 1 },
     },
 
-    // src: mr_fr_2021_ed3
+    // src:
+    // - mr_fr_2021_ed3
+    // - https://www.cccb.ca/wp-content/uploads/2026/03/CanLitCalUpdated_2025_04_01.pdf
+    // - https://www.cccb.ca/wp-content/uploads/2026/07/Ordo_2025_2026_Updates.pdf
     marie_leonie_paradis_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 4 },
@@ -224,5 +229,16 @@ export class Canada extends CalendarDef {
       isOptional: true,
       commonsDef: Common.DedicationAnniversary_Inside,
     },
+
+    // src: mr_fr_2021_ed3
+    remembrance_day: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 11, date: 11 },
+      // One Remembrance Day Mass may be celebrated; the other Masses remain those of Saint Martin of Tours.
+      isOptional: true,
+      commonsDef: Common.None,
+    },
   };
 }
+
+export { Canada_Quebec };

--- a/rites/roman1969/src/calendars/countries/canada/quebec.ts
+++ b/rites/roman1969/src/calendars/countries/canada/quebec.ts
@@ -1,0 +1,33 @@
+import { CommonDefinition as Common } from '../../../constants/commons';
+import { PatronTitle } from '../../../constants/martyrology-metadata';
+import { Precedences } from '../../../constants/precedences';
+import { CalendarDef } from '../../../models/calendar-def';
+import { Inputs } from '../../../types/calendar-def';
+
+import { Canada } from '.';
+
+export class Canada_Quebec extends CalendarDef {
+  ParentCalendars = [Canada];
+
+  inputs: Inputs = {
+    // In the Canadian province of Quebec, the proper feast celebrates Saint Anne alone
+    // rather than Saint Anne and Saint Joachim together.
+    // src: mr_fr_2021_ed3
+    joachim_and_anne_parents_of_mary: {
+      drop: true,
+    },
+
+    // src: mr_fr_2021_ed3
+    anne_mother_of_mary_patroness_of_the_province_of_quebec: {
+      precedence: Precedences.ProperFeast_PrincipalPatronOfARegion_8c,
+      dateDef: { month: 7, date: 26 },
+      commonsDef: Common.None,
+      martyrology: [
+        {
+          id: 'anne_mother_of_mary',
+          titles: { append: [PatronTitle.PatronessOfTheProvinceOfQuebec] },
+        },
+      ],
+    },
+  };
+}

--- a/rites/roman1969/src/calendars/index.ts
+++ b/rites/roman1969/src/calendars/index.ts
@@ -7,7 +7,7 @@ import { Belgium } from './countries/belgium';
 import { Bolivia } from './countries/bolivia';
 import { BosniaHerzegovina } from './countries/bosnia-herzegovina';
 import { Brazil } from './countries/brazil';
-import { Canada } from './countries/canada';
+import { Canada, Canada_Quebec } from './countries/canada';
 import { Chile } from './countries/chile';
 import { China } from './countries/china';
 import { CostaRica } from './countries/costa-rica';
@@ -97,6 +97,7 @@ export const calendarDefinitions: Record<string, typeof CalendarDef> = {
   BosniaHerzegovina,
   Brazil,
   Canada,
+  Canada_Quebec,
   Chile,
   China,
   CostaRica,

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -4414,8 +4414,9 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Virgin],
       dateOfDeath: 1898,
     },
+    // src: https://www.vatican.va/content/francesco/fr/events/event.dir.html/content/vaticanevents/fr/2024/10/20/messa-canonizzazione.html
     marie_leonie_paradis_virgin: {
-      canonizationLevel: CanonizationLevels.Blessed,
+      canonizationLevel: CanonizationLevels.Saint,
       name: 'Marie-Léonie Paradis',
       titles: [Title.Virgin],
       dateOfDeath: 1912,

--- a/rites/roman1969/src/locales/cs.ts
+++ b/rites/roman1969/src/locales/cs.ts
@@ -542,7 +542,7 @@ export const locale: Locale = {
     marianne_cope_virgin: 'Sv. Mariany z Molokai, řeholnice',
     marie_anne_blondin_virgin: 'Bl. Marie Anny Blondin, panny',
     marie_eugenie_of_jesus_milleret_de_brou_virgin: 'Sv. Marie Evženie Milleretové de Brou, panny a zakladatelky',
-    marie_leonie_paradis_virgin: 'Bl. Marie Léonie Paradis, panny',
+    marie_leonie_paradis_virgin: 'Sv. Marie Léonie Paradis, panny',
     marie_rose_durocher_virgin: 'Bl. Marie Rose Durocher, panny',
     mark_evangelist: 'Sv. Marka, evangelisty',
     marko_krizin_melchior_grodziecki_and_stephen_pongracz_priests:

--- a/rites/roman1969/src/locales/de.ts
+++ b/rites/roman1969/src/locales/de.ts
@@ -585,7 +585,7 @@ export const locale: Locale = {
     marie_anne_blondin_virgin: 'Sel. Marie-Anne Blondin, Jungfrau',
     marie_eugenie_of_jesus_milleret_de_brou_virgin:
       'Hl. Marie-Eugénie von Jesus Milleret de Brou, Jungfrau und Gründerin',
-    marie_leonie_paradis_virgin: 'Sel. Marie-Léonie Paradis, Jungfrau',
+    marie_leonie_paradis_virgin: 'Hl. Marie-Léonie Paradis, Jungfrau',
     marie_of_saint_ignatius_claudine_thevenet_religious: 'Hl. Claudine Thévenet, Ordensfrau',
     marie_rose_durocher_virgin: 'Sel. Marie Rose Durocher, Jungfrau',
     mark_evangelist: 'Hl. Markus, Evangelist',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -126,6 +126,8 @@ export const locale: Locale = {
     andrew_zorard_of_nitra_and_benedict_of_skalka_hermits: 'Saints Andrew Zorard and Benedict, Hermits',
     angela_merici_virgin: 'Saint Angela Merici, Virgin',
     angela_salawa_virgin: 'Blessed Angela Salawa, Virgin',
+    anne_mother_of_mary_patroness_of_the_province_of_quebec:
+      'Saint Anne, Mother of the Blessed Virgin Mary, Patroness of the Province of Quebec, both Ecclesiastical and Civil',
     annemund_of_lyon_bishop: 'Saint Annemund, Bishop and Martyr',
     annette_pelras_virgin: 'Saint Annette Pelras, Virgin and Martyr',
     annette_pelras_virgin_and_companions_martyrs:
@@ -837,7 +839,7 @@ export const locale: Locale = {
     marie_anne_blondin_virgin: 'Blessed Marie-Anne Blondin, Virgin',
     marie_eugenie_of_jesus_milleret_de_brou_virgin:
       'Saint Marie-Eugénie of Jesus Milleret de Brou, Virgin and Foundress',
-    marie_leonie_paradis_virgin: 'Blessed Marie-Léonie Paradis, Virgin',
+    marie_leonie_paradis_virgin: 'Saint Marie-Léonie Paradis, Virgin',
     marie_madeleine_julie_francoise_catherine_postel_virgin: 'Saint Marie Madeleine Postel, Virgin',
     marie_of_saint_ignatius_claudine_thevenet_religious: 'Saint Claudine Thévenet, Religious',
     marie_rose_durocher_virgin: 'Blessed Marie Rose Durocher, Virgin',
@@ -1112,6 +1114,7 @@ export const locale: Locale = {
     raymond_gayrard_religious: 'Saint Raymond Gayrard, Religious',
     raymond_of_barbastro_bishop: 'Saint Raymond of Barbastro, Bishop',
     raymond_of_penyafort_priest: 'Saint Raymond of Penyafort, Priest',
+    remembrance_day: 'Remembrance Day',
     remigius_of_gap_and_tigidius_of_gap_bishops: 'Saints Remigius and Tigidius, Bishops',
     remigius_of_gap_bishop: 'Saint Remigius of Gap, Bishop',
     remigius_of_reims_bishop: 'Saint Remigius, Bishop',

--- a/rites/roman1969/src/locales/fr.ts
+++ b/rites/roman1969/src/locales/fr.ts
@@ -104,6 +104,8 @@ export const locale: Locale = {
       'Saints André Svorad († 1009) et Benoît Stojislav († 1012), ermites',
     angela_merici_virgin:
       'Sainte Angèle Mérici, religieuse, fondatrice de la Compagnie de Sainte Ursule de Brescia († 1540)',
+    anne_mother_of_mary_patroness_of_the_province_of_quebec:
+      'Sainte Anne, mère de la Bienheureuse Vierge Marie, patronne de la province, tant ecclésiastique que civile, de Québec',
     annemund_of_lyon_bishop: 'Saint Ennemond (Chamond), évêque et martyr († v. 658)', // src: mr_fr_2014_ed2_lyon
     annette_pelras_virgin: 'Sainte Annette Pelras, vierge et martyre († 1794)',
     annette_pelras_virgin_and_companions_martyrs:
@@ -589,7 +591,7 @@ export const locale: Locale = {
     marie_eugenie_of_jesus_milleret_de_brou_virgin:
       'Sainte Marie-Eugénie Milleret, vierge, fondatrice des Sœurs de l’Assomption († 1898 à Paris)',
     marie_leonie_paradis_virgin:
-      'Bienheureuse Marie-Léonie Paradis, religieuse, fondatrice de la Congrégation des Petites Sœurs de la Sainte Famille († 1912)',
+      'Sainte Marie-Léonie Paradis, religieuse, fondatrice de la Congrégation des Petites Sœurs de la Sainte Famille († 1912)',
     marie_madeleine_julie_francoise_catherine_postel_virgin: 'Sainte Marie Madeleine Postel, vierge († 1846)', // src: mr_fr_1982_ed2_coutances
     marie_of_saint_ignatius_claudine_thevenet_religious: 'Sainte Claudine Thévenet, religieuse († 1837)', // src: mr_fr_2014_ed2_lyon
     marie_rose_durocher_virgin:
@@ -754,6 +756,7 @@ export const locale: Locale = {
     raymond_gayrard_religious: 'Saint Raymond Gayrard, religieux († 1118)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     raymond_of_barbastro_bishop: 'Saint Raymond de Barbastro, évêque († 1126)',
     raymond_of_penyafort_priest: 'Saint Raymond de Peñafort, prêtre († 1275)',
+    remembrance_day: 'Jour du souvenir',
     remigius_of_gap_and_tigidius_of_gap_bishops: 'Saint Rémi et saint Tigide, évêques', // src: mr_fr_2016_ed1_gap_embrun
     remigius_of_gap_bishop: 'Saint Rémi, évêque de Gap', // src: mr_fr_2016_ed1_gap_embrun
     remigius_of_reims_bishop: 'Saint Remi, évêque de Reims († 530)',

--- a/rites/roman1969/src/locales/la.ts
+++ b/rites/roman1969/src/locales/la.ts
@@ -547,7 +547,7 @@ export const locale: Locale = {
     marianne_cope_virgin: 'S. Mariæ Annæ Cope, virginis',
     marie_anne_blondin_virgin: 'B. Mariæ Annæ Blondin, virginis',
     marie_eugenie_of_jesus_milleret_de_brou_virgin: 'S. Mariæ Eugeniæ a Iesu Milleret de Brou, virginis et fundatricis',
-    marie_leonie_paradis_virgin: 'B. Mariæ Leoniæ Paradis, virginis',
+    marie_leonie_paradis_virgin: 'S. Mariæ Leoniæ Paradis, virginis',
     marie_rose_durocher_virgin: 'B. Mariæ Rosæ Durocher, virginis',
     mark_evangelist: 'S. Marci, evangelistæ',
     marko_krizin_melchior_grodziecki_and_stephen_pongracz_priests:

--- a/rites/roman1969/src/locales/sk.ts
+++ b/rites/roman1969/src/locales/sk.ts
@@ -562,7 +562,7 @@ export const locale: Locale = {
     marianne_cope_virgin: 'Svätej Marianny z Molokai, rehoľníčky',
     marie_anne_blondin_virgin: 'Blahoslavenej Márie Anny Blondinovej, panny',
     marie_eugenie_of_jesus_milleret_de_brou_virgin: 'Svätej Márie Eugénie Milleretovej de Brou, panny a zakladateľky',
-    marie_leonie_paradis_virgin: 'Blahoslavenej Márie Leónie Paradisovej, panny',
+    marie_leonie_paradis_virgin: 'Svätej Márie Leónie Paradisovej, panny',
     marie_rose_durocher_virgin: 'Blahoslavenej Márie Ruženy Durocherovej, panny',
     mark_evangelist: 'Svätého Marka, evanjelistu',
     marko_krizin_melchior_grodziecki_and_stephen_pongracz_priests:

--- a/rites/roman1969/src/locales/ta.ts
+++ b/rites/roman1969/src/locales/ta.ts
@@ -567,7 +567,7 @@ export const locale: Locale = {
     marianne_cope_virgin: 'புனித மேரியான் கோப் - கன்னி',
     marie_anne_blondin_virgin: 'முத்திபேறுபெற்ற மேரி-ஆன் புளொடின் - கன்னி',
     marie_eugenie_of_jesus_milleret_de_brou_virgin: 'புனித மேரி-யூஹினி டி ஜீசஸ் - துறவி, நிறுவநர்',
-    marie_leonie_paradis_virgin: 'முத்திப்பேறுபெற்ற மாரி-லியோனி பாரதிஸ் - கன்னி',
+    marie_leonie_paradis_virgin: 'புனித மாரி-லியோனி பாரதிஸ் - கன்னி',
     marie_rose_durocher_virgin: 'முத்திப்பேறுபெற்ற மாரி ரோஸ் துரோச்சர் - கன்னி',
     mark_evangelist: 'புனித மாற்கு - நற்செய்தியாளர்',
     marko_krizin_melchior_grodziecki_and_stephen_pongracz_priests:


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR aligns the Canadian calendar with the *Proper of Canada* from the third French-language edition of the Roman Missal (2021) and adds the proper calendar of the **Canadian province of Quebec**.

It:
- adds Remembrance Day on November 11 as an optional celebration alongside Saint Martin of Tours;
- updates Saint Marie-Léonie Paradis following her canonization in 2024;
- adds the calendar of the Province of Quebec, where Saint Anne alone is celebrated on July 26 as patroness of Quebec, both ecclesiastical and civil;
- adds the corresponding martyrology metadata, localization, calendar registration, and package documentation.

## Sources

- `mr_fr_2021_ed3` — Proper of Canada
- [Updated Liturgical Calendar for Canada](https://www.cccb.ca/wp-content/uploads/2026/03/CanLitCalUpdated_2025_04_01.pdf)
- [CCCB Ordo updates for 2025–2026](https://www.cccb.ca/wp-content/uploads/2026/07/Ordo_2025_2026_Updates.pdf)
- [Canonization of Marie-Léonie Paradis](https://www.vatican.va/content/francesco/en/events/event.dir.html/content/vaticanevents/en/2024/10/20/messa-canonizzazione.html)

---

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).