### PR TITLE
fix(belgium): align calendar with the 2021 proper

### DIFF
--- a/rites/roman1969/__tests__/belgium-calendar.test.ts
+++ b/rites/roman1969/__tests__/belgium-calendar.test.ts
@@ -1,0 +1,25 @@
+import { Belgium_En } from '@dist/rite-roman1969/bundles/belgium';
+import { Romcal } from '@src/rite-roman1969';
+
+describe('Belgium calendar', () => {
+  test('uses the Belgian list of holy days of obligation', async () => {
+    const calendar = Object.values(await new Romcal({ localizedCalendar: Belgium_En }).generateCalendar(2021)).flat();
+    const isHolyDayOfObligation = (id: string) => calendar.find((day) => day.id === id)?.isHolyDayOfObligation;
+
+    const suppressedObligations = [
+      'mary_mother_of_god',
+      'joseph_spouse_of_mary',
+      'peter_and_paul_apostles',
+      'immaculate_conception_of_the_blessed_virgin_mary',
+    ];
+    const belgianObligations = [
+      'nativity_of_the_lord',
+      'ascension_of_the_lord',
+      'assumption_of_the_blessed_virgin_mary',
+      'all_saints',
+    ];
+
+    expect(suppressedObligations.map(isHolyDayOfObligation)).toEqual([false, false, false, false]);
+    expect(belgianObligations.map(isHolyDayOfObligation)).toEqual([true, true, true, true]);
+  });
+});

--- a/rites/roman1969/src/calendars/countries/belgium/index.ts
+++ b/rites/roman1969/src/calendars/countries/belgium/index.ts
@@ -1,50 +1,105 @@
+import { CommonDefinition as Common } from '../../../constants/commons';
+import { PatronTitle } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
-import { Inputs } from '../../../types/calendar-def';
+import type { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Belgium extends CalendarDef {
   ParentCalendars = [Europe];
 
+  particularConfig: ParticularConfig = {
+    epiphanyOnSunday: true, // src: mr_fr_2021_ed3
+    ascensionOnSunday: false, // src: https://newsletter.cathobel.be/CIPL/Calendrier-liturgique-Belgique-2021-2022.pdf
+    corpusChristiOnSunday: true, // src: https://newsletter.cathobel.be/CIPL/Calendrier-liturgique-Belgique-2021-2022.pdf
+  };
+
   inputs: Inputs = {
-    mutien_marie_wiaux_religious: {
-      precedence: Precedences.ProperMemorial_11b,
-      dateDef: { month: 1, date: 30 },
+    // src:
+    // - https://www.otheo.be/bisschoppenconferentie/artikel/decreten-van-de-bisschoppenconferentie-van-belgie
+    // - https://www.cathobel.be/eglise-en-belgique/la-conference-des-eveques/decrets/
+    mary_mother_of_god: {
+      isHolyDayOfObligation: false,
     },
 
+    // src:
+    // - https://www.otheo.be/bisschoppenconferentie/artikel/decreten-van-de-bisschoppenconferentie-van-belgie
+    // - https://www.cathobel.be/eglise-en-belgique/la-conference-des-eveques/decrets/
+    epiphany_of_the_lord: {
+      isHolyDayOfObligation: false,
+    },
+
+    // src: mr_fr_2021_ed3
     amand_of_maastricht_bishop: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 2, date: 6 },
+      commonsDef: Common.Founders,
     },
 
-    gertrude_of_nivelles_abbess: {
-      precedence: Precedences.OptionalMemorial_12,
-      dateDef: { month: 3, date: 17 },
+    // src: mr_fr_2021_ed3
+    paul_miki_and_companions_martyrs: {
+      dateDef: { month: 2, date: 7 },
     },
 
-    julie_billiart_virgin: {
-      precedence: Precedences.ProperMemorial_11b,
-      dateDef: { month: 4, date: 8 },
+    // src:
+    // - mr_fr_2021_ed3
+    // - https://www.otheo.be/bisschoppenconferentie/artikel/decreten-van-de-bisschoppenconferentie-van-belgie
+    // - https://www.cathobel.be/eglise-en-belgique/la-conference-des-eveques/decrets/
+    joseph_spouse_of_mary: {
+      customLocaleId: 'joseph_spouse_of_mary_principal_patron_of_belgium',
+      precedence: Precedences.ProperSolemnity_PrincipalPatron_4a,
+      titles: { append: [PatronTitle.PatronOfBelgium] },
+      isHolyDayOfObligation: false,
     },
 
+    // src: mr_fr_2021_ed3
     damien_de_veuster_priest: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 5, date: 10 },
+      commonsDef: Common.None,
     },
 
+    // This celebration is a mandatory memorial in the Diocese of Ghent.
+    // src: mr_fr_2021_ed3
+    edward_poppe_priest: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 6, date: 10 },
+      commonsDef: Common.Pastors,
+    },
+
+    // src:
+    // - https://www.otheo.be/bisschoppenconferentie/artikel/decreten-van-de-bisschoppenconferentie-van-belgie
+    // - https://www.cathobel.be/eglise-en-belgique/la-conference-des-eveques/decrets/
+    most_holy_body_and_blood_of_christ: {
+      isHolyDayOfObligation: false,
+    },
+
+    // src:
+    // - https://www.otheo.be/bisschoppenconferentie/artikel/decreten-van-de-bisschoppenconferentie-van-belgie
+    // - https://www.cathobel.be/eglise-en-belgique/la-conference-des-eveques/decrets/
+    peter_and_paul_apostles: {
+      isHolyDayOfObligation: false,
+    },
+
+    // src: mr_fr_2021_ed3
     juliana_of_liege_virgin: {
-      precedence: Precedences.ProperMemorial_11b,
+      precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 7 },
+      commonsDef: [Common.Virgins, Common.Religious],
     },
 
+    // src: mr_fr_2021_ed3
     our_lady_mediatrix_of_all_grace: {
-      precedence: Precedences.ProperFeast_8f,
+      precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 31 },
+      commonsDef: Common.BlessedVirginMary,
     },
 
+    // src: mr_fr_2021_ed3
     lambert_of_maastricht_bishop: {
-      precedence: Precedences.ProperMemorial_11b,
+      precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 17 },
+      commonsDef: [Common.Martyrs, Common.Bishops],
     },
 
     // src: mr_fr_2021_ed3
@@ -53,16 +108,28 @@ export class Belgium extends CalendarDef {
       dateDef: { month: 10, date: 25 },
       alternativeTransferDateDefs: [{ dateDef: { month: 10, lastDayOfWeekInMonth: 0 } }],
       isOptional: true,
+      commonsDef: Common.DedicationAnniversary_Inside,
     },
 
+    // src: mr_fr_2021_ed3
     hubert_of_liege_bishop: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 11, date: 3 },
+      commonsDef: Common.Bishops,
     },
 
+    // src: mr_fr_2021_ed3
     john_berchmans_religious: {
-      precedence: Precedences.ProperMemorial_11b,
+      precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 26 },
+      commonsDef: Common.Religious,
+    },
+
+    // src:
+    // - https://www.otheo.be/bisschoppenconferentie/artikel/decreten-van-de-bisschoppenconferentie-van-belgie
+    // - https://www.cathobel.be/eglise-en-belgique/la-conference-des-eveques/decrets/
+    immaculate_conception_of_the_blessed_virgin_mary: {
+      isHolyDayOfObligation: false,
     },
   };
 }

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -1945,6 +1945,17 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Edmund of Abingdon',
       titles: [Title.Bishop],
     },
+    // src:
+    // - mr_fr_2021_ed3
+    // - https://www.vatican.va/content/john-paul-ii/la/apost_letters/1999/documents/hf_jp-ii_apl_19991003_qui-manet.html
+    edward_poppe_priest: {
+      canonizationLevel: CanonizationLevels.Blessed,
+      name: 'Edward Poppe',
+      titles: [Title.Priest],
+      dateOfBirth: '1890-12-18',
+      dateOfDeath: '1924-06-10',
+      dateOfBeatification: '1999-10-03',
+    },
     edward_the_confessor: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Edward the Confessor',

--- a/rites/roman1969/src/constants/martyrology-metadata.ts
+++ b/rites/roman1969/src/constants/martyrology-metadata.ts
@@ -82,6 +82,7 @@ export enum PatronTitle {
   CopatronessOfIreland = 'COPATRONESS_OF_IRELAND',
   CopatronessOfItalyAndEurope = 'COPATRONESS_OF_ITALY_AND_EUROPE',
   CopatronessOfThePhilippines = 'COPATRONESS_OF_THE_PHILIPPINES',
+  PatronOfBelgium = 'PATRON_OF_BELGIUM',
   PatronOfCanada = 'PATRON_OF_CANADA',
   PatronOfEngland = 'PATRON_OF_ENGLAND',
   PatronOfEurope = 'PATRON_OF_EUROPE',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -412,6 +412,7 @@ export const locale: Locale = {
     edmund_campion_priest: 'Saint Edmund Campion, Priest and Martyr',
     edmund_ignatius_rice_religious: 'Blessed Edmund Rice, Religious',
     edmund_of_abingdon_bishop: 'Saint Edmund of Abingdon, Bishop',
+    edward_poppe_priest: 'Blessed Edward Poppe, Priest',
     edward_the_confessor: 'Saint Edward the Confessor',
     eldrad_of_novalesa_abbot: 'Saint Eldrad of Novalesa, Abbot',
     eligius_of_noyon_bishop: 'Saint Eligius, Bishop',
@@ -721,6 +722,8 @@ export const locale: Locale = {
     joseph_sebastian_pelczar_bishop: 'Saint Joseph Sebastian Pelczar, Bishop',
     joseph_spouse_of_mary: 'Saint Joseph, Spouse of the Blessed Virgin Mary',
     joseph_spouse_of_mary_patron_of_canada: 'Saint Joseph, Spouse of the Blessed Virgin Mary, Patron of Canada',
+    joseph_spouse_of_mary_principal_patron_of_belgium:
+      'Saint Joseph, Spouse of the Blessed Virgin Mary, Principal Patron of Belgium',
     joseph_the_worker: 'Saint Joseph the Worker',
     joseph_vaz_priest: 'Saint Joseph Vaz, Priest',
     joseph_yuan_gengyin_priest: 'Saint Joseph Yuan Gengyin, Priest and Martyr',

--- a/rites/roman1969/src/locales/fr.ts
+++ b/rites/roman1969/src/locales/fr.ts
@@ -314,6 +314,7 @@ export const locale: Locale = {
     donatus_of_sisteron_priest_and_may_of_bodon_abbot:
       'Saint Donat, prêtre et ermite († v. 522), et saint May, abbé († v. 550)', // src: mr_fr_2016_ed1_gap_embrun
     easter_sunday: 'Dimanche de Pâques - La résurrection du Seigneur',
+    edward_poppe_priest: 'Bienheureux Édouard Poppe, prêtre († 1924)',
     eldrad_of_novalesa_abbot: 'Saint Eldrad, abbé de la Novalaise († 875)', // src: mr_fr_2016_ed1_gap_embrun
     eligius_of_noyon_bishop: 'Saint Éloi, évêque',
     elijah_prophet: 'Saint Élie, prophète († IXe s. av. J.-C.)',
@@ -518,6 +519,8 @@ export const locale: Locale = {
     joseph_of_calasanz_priest: 'Saint Joseph de Calasanz, prêtre († 1648)',
     joseph_spouse_of_mary: 'Saint Joseph, Époux de la vierge Marie',
     joseph_spouse_of_mary_patron_of_canada: 'Saint Joseph, Époux de la Bienheureuse vierge Marie, patron du Canada',
+    joseph_spouse_of_mary_principal_patron_of_belgium:
+      'Saint Joseph, Époux de la Bienheureuse Vierge Marie, patron principal de la Belgique',
     joseph_the_worker: 'Saint Joseph, Artisan († Ier s.)',
     josephine_bakhita_virgin: 'Sainte Joséphine Bakhita, vierge et religieuse († 1947)',
     juan_diego_cuauhtlatoatzin: 'Saint Juan Diego Cuauhtlatoatzin († 1548)',


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR aligns the Belgian calendar with the *Proper of Belgium* from the third French-language edition of the Roman Missal (2021).

It adds the missing transfer of Saints Paul Miki and Companions, Saint Joseph as Principal Patron of Belgium, and Blessed Edward Poppe; corrects ranks and commons; and removes celebrations that belong to more particular diocesan calendars rather than the national proper.

It also configures the Belgian observance of Epiphany, Ascension, and Corpus Christi, and aligns holy days of obligation with the decree of the Belgian Bishops’ Conference.

## Sources

- `mr_fr_2021_ed3` — Proper of Belgium
- [Belgian Bishops’ Conference decrees — Otheo](https://www.otheo.be/bisschoppenconferentie/artikel/decreten-van-de-bisschoppenconferentie-van-belgie)
- [Belgian Bishops’ Conference decrees — CathoBel](https://www.cathobel.be/eglise-en-belgique/la-conference-des-eveques/decrets/)
- [Belgian liturgical calendar 2021–2022 — CIPL](https://newsletter.cathobel.be/CIPL/Calendrier-liturgique-Belgique-2021-2022.pdf)
- [Interdiocesan Commission for Liturgy — current liturgical calendar](https://www.otheo.be/icl/liturgische-kalender)
- [Apostolic Letter concerning Blessed Edward Poppe](https://www.vatican.va/content/john-paul-ii/la/apost_letters/1999/documents/hf_jp-ii_apl_19991003_qui-manet.html)

---

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).