### PR TITLE
fix(united-states): align calendar with the Roman Missal

### DIFF
--- a/rites/roman1969/src/calendars/countries/united-states/index.ts
+++ b/rites/roman1969/src/calendars/countries/united-states/index.ts
@@ -1,3 +1,5 @@
+import { Colors } from '../../../constants/colors';
+import { CommonDefinition as Common } from '../../../constants/commons';
 import { PatronTitle } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
@@ -8,125 +10,212 @@ export class UnitedStates extends CalendarDef {
   ParentCalendars = [Americas];
 
   particularConfig: ParticularConfig = {
-    epiphanyOnSunday: true,
-    // TODO: Ascension is celebrated on Thursday in the following ecclesiastical provinces (in all other 26 EP, it is celebrated on Sunday): Boston, Hartford, New York, Newark, Omaha, Philadelphia
-    ascensionOnSunday: true,
-    corpusChristiOnSunday: true,
+    epiphanyOnSunday: true, // src: mr_en_2011_ed3_us
+    // The Ascension is celebrated on Thursday in the ecclesiastical provinces of Boston, Hartford,
+    // New York, Omaha, and Philadelphia, and on Sunday in all other United States provinces.
+    ascensionOnSunday: true, // src: https://www.usccb.org/resources/2027cal.pdf#page=8
+    corpusChristiOnSunday: true, // src: mr_en_2011_ed3_us
   };
 
   inputs: Inputs = {
+    // src: mr_en_2011_ed3_us
     elizabeth_ann_seton_religious: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 1, date: 4 },
+      commonsDef: Common.None,
     },
 
+    // src: mr_en_2011_ed3_us
     john_nepomucene_neumann_bishop: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 1, date: 5 },
+      commonsDef: Common.None,
     },
 
+    // src: mr_en_2011_ed3_us
     andre_bessette_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 6 },
+      commonsDef: Common.Religious,
     },
 
+    // When this observance is transferred to January 23, the Optional Memorials of Saint Vincent
+    // and Saint Marianne Cope may be celebrated only in the Liturgy of the Hours. Romcal does not
+    // currently distinguish the calendar of the Mass from that of the Liturgy of the Hours.
+    // src:
+    // - mr_en_2011_ed3_us
+    // - https://www.usccb.org/resources/2023cal.pdf#page=15
+    day_of_prayer_for_the_legal_protection_of_unborn_children: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 1, date: 22 },
+      dateExceptions: {
+        ifIsDayOfWeek: 0,
+        setDate: { addDay: 1 },
+      },
+      commonsDef: Common.None,
+      colors: [Colors.White, Colors.Purple],
+    },
+
+    // src: mr_en_2011_ed3_us
     vincent_of_saragossa_deacon: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 23 },
     },
 
+    // src: https://www.usccb.org/prayer-and-worship/liturgical-year-and-calendar/saint-marianne-cope
     marianne_cope_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 23 },
+      commonsDef: [Common.Virgins, Common.MercyWorkers],
     },
 
+    // src: mr_en_2011_ed3_us
     katharine_drexel_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 3 },
+      commonsDef: Common.Virgins,
     },
 
+    // In the United States, the obligation attached to Mary, Mother of God, the Assumption, and
+    // All Saints is abrogated when the celebration falls on a Saturday or a Monday. The current
+    // calendar input supports only a static obligation flag. Hawaii follows a distinct norm under
+    // which only the Immaculate Conception and Christmas are holy days of obligation; this requires
+    // a dedicated child calendar.
+    // src: https://www.usccb.org/beliefs-and-teachings/what-we-believe/canon-law/complementary-norms/canon-1246
+
+    // Saint Joseph is not a holy day of obligation in the United States.
+    // src: https://www.usccb.org/beliefs-and-teachings/what-we-believe/canon-law/complementary-norms/canon-1246
+    joseph_spouse_of_mary: {
+      isHolyDayOfObligation: false,
+    },
+
+    // src: mr_en_2011_ed3_us
     damien_de_veuster_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 10 },
+      commonsDef: Common.Missionaries,
     },
 
+    // src: mr_en_2011_ed3_us
     isidore_the_farmer: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 15 },
+      commonsDef: Common.Saints,
     },
 
+    // Saints Peter and Paul are not a holy day of obligation in the United States.
+    // src: https://www.usccb.org/beliefs-and-teachings/what-we-believe/canon-law/complementary-norms/canon-1246
+    peter_and_paul_apostles: {
+      isHolyDayOfObligation: false,
+    },
+
+    // src: mr_en_2011_ed3_us
     junipero_serra_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 1 },
+      commonsDef: [Common.Missionaries, Common.Pastors],
     },
 
+    // src: mr_en_2011_ed3_us
+    independence_day: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 7, date: 4 },
+      commonsDef: Common.None,
+      colors: Colors.White,
+    },
+
+    // src: mr_en_2011_ed3_us
     elizabeth_of_portugal: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 5 },
     },
 
+    // src:
+    // - mr_en_2011_ed3_us
+    // - https://www.usccb.org/prayer-worship/liturgical-year/saint-kateri-tekakwitha
     kateri_tekakwitha_virgin: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 7, date: 14 },
+      commonsDef: Common.None,
     },
 
+    // src: mr_en_2011_ed3_us
     camillus_de_lellis_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 18 },
     },
 
+    // src: mr_en_2011_ed3_us
     peter_claver_priest: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 9, date: 9 },
     },
 
+    // src: https://www.usccb.org/prayer-and-worship/liturgical-year-and-calendar/blessed-francis-xavier-seelos
     francis_xavier_seelos_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 5 },
+      commonsDef: Common.Missionaries,
     },
 
+    // src: mr_en_2011_ed3_us
     marie_rose_durocher_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 6 },
+      commonsDef: Common.Virgins,
     },
 
+    // src: mr_en_2011_ed3_us
     john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs: {
       precedence: Precedences.ProperMemorial_11b,
       martyrology: ['john_de_brebeuf_priest', 'isaac_jogues_priest', 'companions_martyrs'],
     },
 
+    // src: mr_en_2011_ed3_us
     paul_of_the_cross_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 20 },
     },
 
+    // src: mr_en_2011_ed3_us
     frances_xavier_cabrini_virgin: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 11, date: 13 },
+      commonsDef: [Common.Virgins, Common.MercyWorkers],
     },
 
+    // src: mr_en_2011_ed3_us
     rose_philippine_duchesne_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 18 },
+      commonsDef: Common.Virgins,
     },
 
+    // src: mr_en_2011_ed3_us
     miguel_agustin_pro_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 23 },
+      commonsDef: [Common.Martyrs, Common.Pastors],
     },
 
-    // It is a holiday of obligation unless it occurs with Sunday:
-    // then it is moved to the following Monday and while keeps its rank (solemnity),
-    // it is not a holiday of obligation
+    // src: mr_en_2011_ed3_us
+    thanksgiving_day: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 11, nthWeekInMonth: 4, dayOfWeek: 4 },
+      commonsDef: Common.None,
+      colors: Colors.White,
+    },
+
+    // When transferred from an Advent Sunday to Monday, the celebration remains a Solemnity but
+    // the obligation does not transfer. The current calendar input supports only a static obligation flag.
+    // src:
+    // - mr_en_2011_ed3_us
+    // - https://www.usccb.org/resources/newsletter-2025-02.pdf
     immaculate_conception_of_the_blessed_virgin_mary: {
       customLocaleId: 'immaculate_conception_of_the_blessed_virgin_mary_patroness_of_the_usa',
       precedence: Precedences.ProperSolemnity_PrincipalPatron_4a,
       isHolyDayOfObligation: true,
-      // isHolyDayOfObligation: () => this.dates.immaculateConceptionOfMary().day() === 0,
       titles: { append: [PatronTitle.PatronessOfTheUSA] },
-      // afterBuild: (def) => {
-      //   def.isHolyDayOfObligation = this.dates.immaculateConceptionOfMary().day() === 0;
-      // },
     },
   };
 }

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -351,6 +351,8 @@ export const locale: Locale = {
     david_of_wales_bishop: 'Saint David, Bishop',
     david_of_wales_bishop_patron_of_wales: 'Saint David, Bishop, Patron of Wales',
     davnet_of_sliabh_beagh_virgin: 'Saint Davnet, Virgin',
+    day_of_prayer_for_the_legal_protection_of_unborn_children:
+      'Day of Prayer for the Legal Protection of Unborn Children', // src: mr_en_2011_ed3_us
     declan_of_ardmore_bishop: 'Saint Declan, Bishop',
     dedication_of_consecrated_churches: 'The Dedication of Consecrated Churches Whose Date of Consecration is Unknown',
     dedication_of_notre_dame_cathedral_luxembourg: 'Dedication of Notre-Dame Cathedral, Luxembourg',
@@ -523,7 +525,7 @@ export const locale: Locale = {
     francis_of_paola_hermit: 'Saint Francis of Paola, Hermit',
     francis_solanus_priest: 'Saint Francis Solanus, Priest',
     francis_xavier_priest: 'Saint Francis Xavier, Priest',
-    francis_xavier_seelos_priest: 'Blessed Francis Xavier Seelos, priest',
+    francis_xavier_seelos_priest: 'Blessed Francis Xavier Seelos, Priest',
     francois_dardan_priest_and_companions_martyrs: 'Blessed François Dardan, Priest, and Companions, Martyrs',
     francois_de_montmorency_laval_bishop: 'Saint François de Laval, Bishop',
     francois_louis_meallet_de_fargues_priest: 'Blessed François-Louis Méallet de Fargues, Priest and Martyr',
@@ -639,6 +641,7 @@ export const locale: Locale = {
     immaculate_conception_of_the_blessed_virgin_mary_principal_patroness_of_the_diocese_of_laval:
       'The Immaculate Conception of the Blessed Virgin Mary, Principal Patroness of the Diocese of Laval', // src: mr_fr_1998_ed1_laval
     immaculate_heart_of_mary: 'The Immaculate Heart of the Blessed Virgin Mary',
+    independence_day: 'Independence Day', // src: mr_en_2011_ed3_us
     innocent_v_pope: 'Blessed Innocent V, Pope',
     innocent_xi_pope: 'Blessed Innocent XI, Pope',
     irenaeus_of_lyon_bishop: 'Saint Irenaeus, Bishop, Martyr and Doctor of the Church',

--- a/rites/roman1969/src/locales/es.ts
+++ b/rites/roman1969/src/locales/es.ts
@@ -48,6 +48,7 @@ export const locale: Locale = {
     amandus_of_strasbourg_bishop: 'San Amand de Estrasburgo, obispo',
     amarin_of_alsace_abbot: 'San Amarino, Abad y mártir',
     ambrose_of_milan_bishop: 'San Ambrosio, obispo y doctor de la Iglesia',
+    andre_bessette_religious: 'San Andrés Bessette, religioso',
     andrew_apostle: 'San Andrés, apóstol',
     andrew_apostle_patron_of_scotland: 'San Andrés, apóstol y Patrono de Escocia',
     andrew_dung_lac_priest_and_companions_martyrs: 'Santos Andrés Dung-Lac, presbítero, y compañeros, mártires',
@@ -149,9 +150,12 @@ export const locale: Locale = {
     cyril_of_alexandria_bishop: 'San Cirilio de Alexandria, obispo y doctor de la Iglesia',
     cyril_of_jerusalem_bishop: 'San Cirilio de Jerusalén, obispo y doctor de la Iglesia',
     damasus_i_pope: 'San Dámaso I, papa',
+    damien_de_veuster_priest: 'San Damián de Veuster, presbítero',
     daniel_brottier_priest: 'Beato Daniel Brottier, presbítero',
     david_of_wales_bishop: 'San David, obispo',
     david_of_wales_bishop_patron_of_wales: 'San David, obispo y Patrono de Gales',
+    day_of_prayer_for_the_legal_protection_of_unborn_children:
+      'Día de oración por la protección legal de la criatura en el vientre materno', // src: https://www.usccb.org/resources/2027cal.pdf
     dedication_of_consecrated_churches: 'Dedicación de iglesias consagradas cuya fecha de Consagración se desconoce', // TODO: l10n to review: Dedication of Consecrated Churches Whose Date of Consecration is Unknown
     dedication_of_the_basilica_of_saint_mary_major: 'Dedicación de la Basílica de Santa María Mayor',
     dedication_of_the_basilicas_of_saints_peter_and_paul_apostles:
@@ -173,6 +177,7 @@ export const locale: Locale = {
     easter_sunday: 'Domingo de Pascua',
     eligius_of_noyon_bishop: 'San Eligio, obispo',
     elijah_prophet: 'San Elías, profeta',
+    elizabeth_ann_seton_religious: 'Santa Isabel Ana Seton, religiosa',
     elizabeth_of_hungary_religious: 'Santa Isabel de Hungría, religiosa',
     elizabeth_of_portugal: 'Santa Isabel de Portugal',
     ephrem_the_syrian_deacon: 'San Efrén de Siria, Diácono y doctor de la Iglesia',
@@ -192,6 +197,7 @@ export const locale: Locale = {
     first_martyrs_of_the_holy_roman_church: 'Primeros mártires de la Iglesia de Roma',
     florentius_of_strasbourg_bishop: 'San Florencio, obispo',
     frances_of_rome_religious: 'Santa Francisca Romana, religiosa',
+    frances_xavier_cabrini_virgin: 'Santa Francisca Javier Cabrini, virgen',
     francis_borgia_priest: 'San Francisco de Borja, presbítero',
     francis_de_sales_bishop: 'San Francisco de Sales, obispo y doctor de la Iglesia',
     francis_diaz_del_rincon_priest_and_companions_martyrs: 'San Francisco Díaz, presbítero y Compañeros, mártires',
@@ -201,6 +207,7 @@ export const locale: Locale = {
     francis_of_paola_hermit: 'San Francisco de Paula, ermitaño',
     francis_solanus_priest: 'San Francisco Solano, presbítero',
     francis_xavier_priest: 'San Francisco Javier, presbítero',
+    francis_xavier_seelos_priest: 'Beato Francisco Javier Seelos, presbítero',
     frederic_ozanam_founder: 'Beato Federico Ozanam, fundador',
     friday_of_the_passion_of_the_lord: 'Viernes Santo',
     fructuosus_of_tarragona_bishop_and_augurius_of_tarragona_and_eulogius_of_tarragona_deacons_martyrs:
@@ -231,7 +238,10 @@ export const locale: Locale = {
     ignatius_of_loyola_priest: 'San Ignacio de Loyola, presbítero',
     ildephonsus_of_toledo_bishop: 'San Ildefonso, obispo de Toledo',
     immaculate_conception_of_the_blessed_virgin_mary: 'Inmaculada Concepción de María',
+    immaculate_conception_of_the_blessed_virgin_mary_patroness_of_the_usa:
+      'Inmaculada Concepción de la Bienaventurada Virgen María, patrona de los Estados Unidos de América',
     immaculate_heart_of_mary: 'Inmaculado Corazón de María',
+    independence_day: 'Día de la Independencia de los Estados Unidos', // src: https://www.usccb.org/es/prayer-and-worship/the-mass/musica-para-el-misal-romano
     innocent_v_pope: 'Beato Inocencio V, papa',
     innocent_xi_pope: 'Beato Inocencio XI, papa',
     irenaeus_of_lyon_bishop: 'San Ireneo de Lyon, obispo, mártir y doctor de la Iglesia',
@@ -262,6 +272,7 @@ export const locale: Locale = {
     john_i_pope: 'San Juan I, papa y mártir',
     john_leonardi_priest: 'San Juan Leonardi, presbítero',
     john_mary_vianney_priest: 'San Juan María Vianney, presbítero',
+    john_nepomucene_neumann_bishop: 'San Juan Nepomuceno Neumann, obispo',
     john_of_avila_priest: 'San Juan de Ávila, presbítero y doctor de la Iglesia',
     john_of_capistrano_priest: 'San Juan de Capistrano, presbítero',
     john_of_god_duarte_cidade_religious: 'San Juan de Dios, religioso',
@@ -281,6 +292,8 @@ export const locale: Locale = {
     juan_diego_cuauhtlatoatzin: 'San Juan Diego Cuauhtlatoatzin',
     junipero_serra_priest: 'San Junípero Serra, presbítero',
     justin_martyr: 'San Justino, mártir',
+    kateri_tekakwitha_virgin: 'Santa Kateri Tekakwitha, virgen',
+    katharine_drexel_virgin: 'Santa Catalina Drexel, virgen',
     landry_of_paris_bishop: 'San Landerico de París, obispo',
     laura_vicuna_virgin: 'Beata Laura Vicuna, virgen',
     lawrence_of_brindisi_priest: 'San Lorenzo de Brindis, presbítero y doctor de la Iglesia',
@@ -306,8 +319,10 @@ export const locale: Locale = {
     maria_guadalupe_garcia_zavala_virgin: 'Santa María Guadalupe García Zavala, virgen',
     maria_micaela_of_the_blessed_sacrament_desmaisieres_virgin: 'Santa María Micaela del Santísimo Sacramento, virgen',
     mariana_of_jesus_de_paredes_virgin: 'Santa Mariana de Jesús de Paredes, virgen',
+    marianne_cope_virgin: 'Santa Mariana Cope, virgen',
     marie_eugenie_of_jesus_milleret_de_brou_virgin:
       'Santa María Eugenia de Jesús Milleret de Brou, virgen y Fundatrice',
+    marie_rose_durocher_virgin: 'Beata María Rosa Durocher, virgen',
     mark_evangelist: 'San Marcos, evangelista',
     martha_of_bethany_mary_of_bethany_and_lazarus_of_bethany: 'Santos Marta, María y Lázaro', // src: https://liturgiapapal.org/attachments/article/1093/PROPIO%20DE%20LOS%20SANTOS.pdf#page=9
     martin_de_porres_religious: 'San Martín de Porres, religioso',
@@ -439,6 +454,7 @@ export const locale: Locale = {
     romuald_of_ravenna_abbot: 'San Romualdo, Abad',
     rosalie_jeanne_marie_rendu_virgin: 'Beata Rosalía Rendu, virgen',
     rose_of_lima_virgin: 'Santa Rosa de Lima, virgen',
+    rose_philippine_duchesne_virgin: 'Santa Rosa Filipina Duchesne, virgen',
     scholastica_of_nursia_virgin: 'Santa Escolástica, virgen',
     sebastian_de_aparicio_religious: 'Beato Sebastián de Aparicio, religioso',
     sebastian_of_milan_martyr: 'San Sebastián, mártir',
@@ -458,6 +474,7 @@ export const locale: Locale = {
     teresa_of_jesus_jornet_ibars_virgin: 'Santa Teresa de Jesús Jornet e Ibars, virgen',
     teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesús, virgen y doctora de la Iglesia',
     teresa_of_jesus_of_los_andes_virgin: 'Santa Teresa de Los Andes, virgen',
+    thanksgiving_day: 'Día de Acción de Gracias', // src: https://www.usccb.org/es/prayer-and-worship/the-mass/musica-para-el-misal-romano
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin:
       'Santa Teresita del Niño Jesús, virgen y doctora de la Iglesia',
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin_copatroness_of_france:

--- a/rites/roman1969/src/locales/fr.ts
+++ b/rites/roman1969/src/locales/fr.ts
@@ -276,6 +276,8 @@ export const locale: Locale = {
     damasus_i_pope: 'Saint Damase Ier, pape († 384)',
     damien_de_veuster_priest: 'Saint Père Damien, prêtre et Missionnaire Picpus († 1889)',
     daniel_brottier_priest: 'Bienheureux Daniel Brottier, prêtre, apôtre des Orphelins d’Auteuil († 1936 à Paris)',
+    day_of_prayer_for_the_legal_protection_of_unborn_children:
+      'Journée de prière pour la protection juridique des enfants à naître',
     dedication_of_consecrated_churches:
       'Dédicace des églises consacrées dont on ne connaît pas la date de consécration', // src: mr_fr_2021_ed3
     dedication_of_notre_dame_cathedral_luxembourg: 'Dédicace de la cathédrale Notre-Dame de Luxembourg', // src: mr_fr_2021_ed3
@@ -339,6 +341,7 @@ export const locale: Locale = {
     eleutherius_of_tournai_bishop: 'Saint Éleuthère, évêque de Tournai († v. 536)',
     eligius_of_noyon_bishop: 'Saint Éloi, évêque',
     elijah_prophet: 'Saint Élie, prophète († IXe s. av. J.-C.)',
+    elizabeth_ann_seton_religious: 'Sainte Élisabeth-Anne Seton, religieuse',
     elizabeth_bichier_des_ages_virgin: 'Sainte Élisabeth Bichier des Âges, vierge († 1838)',
     elizabeth_of_hungary_religious: 'Sainte Élisabeth de Hongrie († 1231)',
     elizabeth_of_portugal: 'Sainte Élisabeth du Portugal, reine († 1336)',
@@ -384,6 +387,7 @@ export const locale: Locale = {
       'Saints Fraimbault, Constantien et Céneré, ermites', // src: mr_fr_1998_ed1_laval
     fraimbault_of_lassay_hermit: 'Saint Fraimbault de Lassay, ermite († 550)', // src: mr_fr_1998_ed1_laval
     frances_of_rome_religious: 'Sainte Françoise Romaine, religieuse († 1440)',
+    frances_xavier_cabrini_virgin: 'Sainte Françoise-Xavière Cabrini, vierge',
     francis_de_sales_bishop: 'Saint François de Sales, évêque et docteur de l’Église († 1622)',
     francis_de_sales_bishop_patron_of_the_clergy_of_the_archdiocese_of_lyon:
       'Saint François de Sales, évêque et docteur de l’Église, patron du clergé lyonnais († 1622)', // src: mr_fr_2014_ed2_lyon
@@ -392,6 +396,7 @@ export const locale: Locale = {
       'Saint François d’Assise, fondateur de l’ordre des Frères mineurs, patron de l’Italie († 1226)',
     francis_of_paola_hermit: 'Saint François de Paule, ermite, fondateur de l’ordre des Minimes († 1507)',
     francis_xavier_priest: 'Saint François-Xavier, prêtre, Jésuite Missionnaire († 1552)',
+    francis_xavier_seelos_priest: 'Bienheureux François-Xavier Seelos, prêtre',
     francois_dardan_priest_and_companions_martyrs:
       'Bienheureux François Dardan, prêtre, et ses compagnons, martyrs († 1792)',
     francois_de_montmorency_laval_bishop: 'Saint François de Laval, premier évêque de Québec († 1708)',
@@ -462,9 +467,12 @@ export const locale: Locale = {
     ignatius_of_antioch_bishop: 'Saint Ignace d’Antioche, évêque et martyr, père et docteur de l’Église († 115)',
     ignatius_of_loyola_priest: 'Saint Ignace de Loyola, prêtre, fondateur de la Compagnie de Jésus († 1556)',
     immaculate_conception_of_the_blessed_virgin_mary: 'Immaculée Conception de la vierge Marie',
+    immaculate_conception_of_the_blessed_virgin_mary_patroness_of_the_usa:
+      'Immaculée Conception de la bienheureuse Vierge Marie, patronne des États-Unis d’Amérique',
     immaculate_conception_of_the_blessed_virgin_mary_principal_patroness_of_the_diocese_of_laval:
       'Immaculée Conception de la Vierge Marie, patronne principale du diocèse', // src: mr_fr_1998_ed1_laval
     immaculate_heart_of_mary: 'Cœur immaculé de Marie',
+    independence_day: 'Jour de l’Indépendance',
     innocent_v_pope: 'Bienheureux Innocent V, pape († 1276)',
     irenaeus_of_lyon_bishop: 'Saint Irénée, évêque, martyr et docteur de l’Église († v. 201)',
     irenaeus_of_lyon_bishop_patron_of_the_archdiocese_of_lyon_and_companions_martyrs:
@@ -472,6 +480,7 @@ export const locale: Locale = {
     irmina_of_oeren_abbess: 'Sainte Irmine, religieuse († v. 710)', // src: mr_fr_2021_ed3
     isabelle_of_france_virgin: 'Bienheureuse Isabelle de France, sœur de saint Louis, vierge († 1270)',
     isidore_of_seville_bishop: 'Saint Isidore de Séville, docteur de l’Église, évêque et Confesseur († 636)',
+    isidore_the_farmer: 'Saint Isidore le Laboureur',
     ivo_of_kermartin_priest: 'Saint Yves Hélory, prêtre et juge en Bretagne († 1303)',
     jacques_berthieu_priest: 'Saint Jacques Berthieu, prêtre et martyr († 1896)',
     jacques_francois_lefranc_martyr_and_martyrs_of_the_revolution:
@@ -536,6 +545,7 @@ export const locale: Locale = {
     john_i_pope: 'Saint Jean Ier, pape et martyr († 526)',
     john_leonardi_priest: 'Saint Jean Léonardi, prêtre († 1609)',
     john_mary_vianney_priest: 'Saint Jean-Marie Vianney, prêtre, curé d’Ars († 1859)',
+    john_nepomucene_neumann_bishop: 'Saint Jean-Népomucène Neumann, évêque',
     john_nepomucene_priest: 'Saint Jean Népomucène, prêtre et martyr († 1393)',
     john_of_avila_priest: 'Saint Jean d’Avila, prêtre et docteur de l’Église († 1569)',
     john_of_capistrano_priest: 'Saint Jean de Capistran, prêtre de l’Ordre des Mineurs († 1456)',
@@ -567,10 +577,12 @@ export const locale: Locale = {
     juliana_of_liege_virgin: 'Sainte Julienne de Cornillon, religieuse Augustine († 1258)',
     julie_billiart_virgin:
       'Sainte Julie Billiart, religieuse, fondatrice de l’Institut des Sœurs de Notre-Dame († 1816)',
+    junipero_serra_priest: 'Saint Junípero Serra, prêtre',
     justin_martyr: 'Saint Justin, martyr († 165)',
     justin_of_bigorre_priest: 'Saint Justin de Bigorre, prêtre († IVe s.)',
     justus_of_lyon_bishop: 'Saint Just, évêque († v. 389)', // src: mr_fr_2014_ed2_lyon
     kateri_tekakwitha_virgin: 'Sainte Kateri Tekakwitha, vierge Amérindienne († 1680)',
+    katharine_drexel_virgin: 'Sainte Katharine Drexel, vierge',
     labor_day: 'Fête du travail', // src: mr_fr_2021_ed3
     lambert_of_maastricht_bishop: 'Saint Lambert, évêque et martyr († 705)',
     landry_of_paris_bishop: 'Saint Landry, évêque de Paris († au 7e s.)',
@@ -625,6 +637,7 @@ export const locale: Locale = {
     marguerite_dyouville_religious:
       'Sainte Marguerite d’Youville, religieuse, fondatrice des Sœurs de la Charité de Montréal († 1771)',
     maria_goretti_virgin: 'Sainte Maria Goretti, vierge et martyre († 1902)',
+    marianne_cope_virgin: 'Sainte Marianne Cope, vierge',
     marie_anne_blondin_virgin:
       'Bienheureuse Marie-Anne Blondin, religieuse, fondatrice des Sœurs de Sainte-Anne († 1890)',
     marie_eugenie_of_jesus_milleret_de_brou_virgin:
@@ -680,6 +693,7 @@ export const locale: Locale = {
     mellitus_of_canterbury_bishop: 'Saint Mellitus de Cantorbéry, évêque',
     michael_gabriel_and_raphael_archangels: 'Saints Michel, Gabriel and Raphaël, archanges',
     michael_garicoits_priest: 'Saint Michel Garicoïts, prêtre († 1863)',
+    miguel_agustin_pro_priest: 'Bienheureux Miguel Agustín Pro, prêtre et martyr',
     misselin_of_tarbes_priest: 'Saint Misselin, prêtre († Ve s.)',
     modestus_andlauer_and_andrew_bauer_martyrs: 'Saints Modeste Andlauer et André Bauer, martyrs († 1900)',
     modestus_andlauer_martyr: 'Saint Modeste Andlauer, martyr († 1900)',
@@ -829,6 +843,7 @@ export const locale: Locale = {
     romuald_of_ravenna_abbot: 'Saint Romuald, anachorète et père des moines Camaldules († 1027)',
     rosalie_jeanne_marie_rendu_virgin: 'Bienheureuse Rosalie Rendu, vierge († 1856)',
     rose_of_lima_virgin: 'Sainte Rose de Lima, vierge († 1617)',
+    rose_philippine_duchesne_virgin: 'Sainte Rose-Philippine Duchesne, vierge',
     roseline_of_villeneuve_virgin: 'Sainte Roseline de Villeneuve, vierge († 1329)', // src: mr_fr_2016_ed1_gap_embrun
     rumpharius_of_coutances_bishop: 'Saint Romphaire, évêque de Coutance († VIème s.)', // src: mr_fr_1982_ed2_coutances
     salome_disciple: 'Sainte Marie Salomé, disciple du Seigneur', // src: mr_fr_1984_ed1_nimes


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR aligns the **United States** calendar with the 2011 Roman Missal and current USCCB norms.

It:
- adds the Day of Prayer for the Legal Protection of Unborn Children, Independence Day, and Thanksgiving Day;
- completes the proper commons and full-formulary declarations;
- corrects the static holy day of obligation settings for Saint Joseph and Saints Peter and Paul;
- updates the Ascension province note;
- verifies recent additions and formularies for Saint Marianne Cope, Blessed Francis Xavier Seelos, and Saint Kateri Tekakwitha;
- completes the corresponding English, French, and Spanish localizations.

Conditional holy day rules that Romcal cannot currently express are documented in the calendar, including the Saturday/Monday exemptions, transferred Immaculate Conception, and the distinct norm for Hawaii.

## Sources

- *The Roman Missal, Third Typical Edition for use in the Dioceses of the United States of America* (2011)
- [USCCB — Proper Calendar](https://www.usccb.org/prayer-and-worship/liturgical-year-and-calendar/proper-calendar)
- [USCCB — Complementary Norms for Canon 1246](https://www.usccb.org/beliefs-and-teachings/what-we-believe/canon-law/complementary-norms/canon-1246)
- [USCCB — Saint Kateri Tekakwitha](https://www.usccb.org/prayer-worship/liturgical-year/saint-kateri-tekakwitha)
- [USCCB — Saint Marianne Cope](https://www.usccb.org/prayer-and-worship/liturgical-year-and-calendar/saint-marianne-cope)
- [USCCB — Blessed Francis Xavier Seelos](https://www.usccb.org/prayer-and-worship/liturgical-year-and-calendar/blessed-francis-xavier-seelos)
- [USCCB — 2027 Liturgical Calendar](https://www.usccb.org/resources/2027cal.pdf)

---

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).