### PR TITLE
feat(calendar): support adjacent-Sunday transfer rules

### DIFF
--- a/docs/general-usage.md
+++ b/docs/general-usage.md
@@ -19,6 +19,11 @@ new Romcal({
   scope: 'gregorian' | 'liturgical',
   localizedCalendar: UnitedStates_En,
   epiphanyOnSunday: true | false,
+  temporalOverrides: {
+    anchorExceptions: {
+      epiphany: [{ when: { dayOfWeek: 'saturday' }, then: { transferTo: 'sunday' } }],
+    },
+  },
   corpusChristiOnSunday: true | false,
   ascensionOnSunday: true | false,
 }).generateCalendar(2020);
@@ -137,6 +142,27 @@ Default:
 
 - `true` (Epiphany is always celebrated a Sunday).
 - Or if provided, defaults to the setting defined in the particular calendar you are fetching through romcal.
+
+Providing `epiphanyOnSunday` explicitly disables inherited Epiphany exceptions unless `temporalOverrides` is also
+provided.
+
+### `temporalOverrides`
+
+Defines calendar-specific exceptions applied after a temporal date has been calculated. For example, this moves an
+Epiphany that falls on Saturday to the adjacent Sunday:
+
+```typescript
+new Romcal({
+  temporalOverrides: {
+    anchorExceptions: {
+      epiphany: [{ when: { dayOfWeek: 'saturday' }, then: { transferTo: 'sunday' } }],
+    },
+  },
+});
+```
+
+An explicitly supplied `temporalOverrides` block takes precedence over both the localized calendar exceptions and
+the `epiphanyOnSunday` option. An empty `anchorExceptions` object therefore disables inherited exceptions.
 
 ### `corpusChristiOnSunday`
 

--- a/rites/roman1969/__tests__/calendar-date-overrides.test.ts
+++ b/rites/roman1969/__tests__/calendar-date-overrides.test.ts
@@ -1,6 +1,7 @@
 import { AsianRussia_En } from '@dist/rite-roman1969/bundles/asian-russia';
 import { CzechRepublic_Cs } from '@dist/rite-roman1969/bundles/czech-republic';
 import { England_En } from '@dist/rite-roman1969/bundles/england';
+import { England_Westminster_En } from '@dist/rite-roman1969/bundles/england.westminster';
 import { Europe_En } from '@dist/rite-roman1969/bundles/europe';
 import { EuropeanRussia_En } from '@dist/rite-roman1969/bundles/european-russia';
 import { France_Fr } from '@dist/rite-roman1969/bundles/france';
@@ -113,6 +114,77 @@ describe('Testing national calendar overrides', () => {
       expect(getUtcDateFromString(epiphanySlovakia!.date).getUTCDay()).toEqual(0);
       expect(getUtcDateFromString(epiphanySlovakia!.date).getUTCMonth()).toEqual(0);
     });
+
+    test('Bundles without temporal anchor exceptions omit the optional configuration', () => {
+      expect(France_Fr.particularConfig).not.toHaveProperty('temporalOverrides');
+    });
+  });
+
+  describe.each([
+    { calendarName: 'England', localizedCalendar: England_En },
+    { calendarName: 'Wales', localizedCalendar: Wales_En },
+  ])('The Epiphany season in $calendarName', ({ localizedCalendar }) => {
+    test('declares the Saturday and Monday transfers in its bundle', () => {
+      expect(localizedCalendar.particularConfig.temporalOverrides).toEqual({
+        anchorExceptions: {
+          epiphany: [
+            { when: { dayOfWeek: 'saturday' }, then: { transferTo: 'sunday' } },
+            { when: { dayOfWeek: 'monday' }, then: { transferTo: 'sunday' } },
+          ],
+        },
+      });
+    });
+
+    test('follows the Saturday transfer and its dependent dates in 2024', async () => {
+      const dates = Object.values(await new Romcal({ localizedCalendar }).generateCalendar(2024)).flat();
+
+      expect(dates.find((d) => d.id === 'christmas_time_january_6')?.date).toEqual('2024-01-06');
+      expect(dates.find((d) => d.id === 'epiphany_of_the_lord')?.date).toEqual('2024-01-07');
+      expect(dates.find((d) => d.id === 'baptism_of_the_lord')?.date).toEqual('2024-01-08');
+      expect(dates.find((d) => d.id === 'ordinary_time_1_tuesday')?.date).toEqual('2024-01-09');
+    });
+
+    test('follows the Monday transfer and its dependent dates in 2025', async () => {
+      const dates = Object.values(await new Romcal({ localizedCalendar }).generateCalendar(2025)).flat();
+
+      expect(dates.find((d) => d.id === 'epiphany_of_the_lord')?.date).toEqual('2025-01-05');
+      expect(dates.find((d) => d.id === 'second_sunday_after_christmas')).toBeUndefined();
+      expect(
+        dates
+          .filter((d) => d.id.endsWith('_after_epiphany'))
+          .map((d) => d.date)
+          .sort()
+      ).toEqual(['2025-01-06', '2025-01-07', '2025-01-08', '2025-01-09', '2025-01-10', '2025-01-11']);
+      expect(dates.find((d) => d.id === 'baptism_of_the_lord')?.date).toEqual('2025-01-12');
+      expect(dates.find((d) => d.id === 'ordinary_time_1_monday')?.date).toEqual('2025-01-13');
+    });
+
+    test('keeps a midweek Epiphany unchanged in 2021', async () => {
+      const dates = Object.values(await new Romcal({ localizedCalendar }).generateCalendar(2021)).flat();
+
+      expect(dates.find((d) => d.id === 'epiphany_of_the_lord')?.date).toEqual('2021-01-06');
+      expect(dates.find((d) => d.id === 'baptism_of_the_lord')?.date).toEqual('2021-01-10');
+      expect(dates.find((d) => d.id === 'ordinary_time_1_monday')?.date).toEqual('2021-01-11');
+    });
+  });
+
+  test('An England child calendar inherits the Epiphany exceptions through its generated bundle', () => {
+    const romcal = new Romcal({ localizedCalendar: England_Westminster_En });
+
+    expect(romcal.config.temporalOverrides).toEqual(England_En.particularConfig.temporalOverrides);
+    expect(romcal.dates(2024).epiphany().toISOString()).toEqual('2024-01-07T00:00:00.000Z');
+  });
+
+  test('Reading and mutating config output does not alter a shared calendar bundle', () => {
+    const exposedExceptions = new Romcal({ localizedCalendar: England_En }).config.temporalOverrides?.anchorExceptions
+      .epiphany as unknown as unknown[] | undefined;
+
+    exposedExceptions?.splice(0);
+
+    expect(England_En.particularConfig.temporalOverrides?.anchorExceptions.epiphany).toHaveLength(2);
+    expect(new Romcal({ localizedCalendar: England_En }).dates(2024).epiphany().toISOString()).toEqual(
+      '2024-01-07T00:00:00.000Z'
+    );
   });
 
   describe('Testing the Feast of Saints Cyril and Methodius with locale specific settings', () => {
@@ -225,6 +297,16 @@ describe('Testing national calendar overrides', () => {
       expect(getUtcDateFromString(allSaintsEngland!.date).getUTCDay()).toEqual(0);
       expect(getUtcDateFromString(allSaintsWales!.date).getUTCDay()).toEqual(0);
     });
+
+    test('If All Saints is on Monday, it will be moved to the previous Sunday', async () => {
+      const englandDates = Object.values(
+        await new Romcal({ localizedCalendar: England_En }).generateCalendar(2021)
+      ).flat();
+      const walesDates = Object.values(await new Romcal({ localizedCalendar: Wales_En }).generateCalendar(2021)).flat();
+
+      expect(englandDates.find((d) => d.id === 'all_saints')?.date).toEqual('2021-10-31');
+      expect(walesDates.find((d) => d.id === 'all_saints')?.date).toEqual('2021-10-31');
+    });
   });
 
   describe('The feast of All Souls in England and Wales', () => {
@@ -240,6 +322,32 @@ describe('Testing national calendar overrides', () => {
       const allSaintsWales = walesDates.find((d) => d.id === 'commemoration_of_all_the_faithful_departed');
       expect(getUtcDateFromString(allSaintsEngland!.date).getUTCDay()).toEqual(1);
       expect(getUtcDateFromString(allSaintsWales!.date).getUTCDay()).toEqual(1);
+    });
+
+    test('It remains on November 2 when All Saints is transferred to the previous Sunday', async () => {
+      const englandDates = Object.values(
+        await new Romcal({ localizedCalendar: England_En }).generateCalendar(2021)
+      ).flat();
+      const walesDates = Object.values(await new Romcal({ localizedCalendar: Wales_En }).generateCalendar(2021)).flat();
+
+      expect(englandDates.find((d) => d.id === 'commemoration_of_all_the_faithful_departed')?.date).toEqual(
+        '2021-11-02'
+      );
+      expect(walesDates.find((d) => d.id === 'commemoration_of_all_the_faithful_departed')?.date).toEqual('2021-11-02');
+    });
+
+    test('It is transferred to Monday when All Saints occupies Sunday November 2', async () => {
+      const englandDates = Object.values(
+        await new Romcal({ localizedCalendar: England_En }).generateCalendar(2025)
+      ).flat();
+      const walesDates = Object.values(await new Romcal({ localizedCalendar: Wales_En }).generateCalendar(2025)).flat();
+
+      expect(englandDates.find((d) => d.id === 'all_saints')?.date).toEqual('2025-11-02');
+      expect(walesDates.find((d) => d.id === 'all_saints')?.date).toEqual('2025-11-02');
+      expect(englandDates.find((d) => d.id === 'commemoration_of_all_the_faithful_departed')?.date).toEqual(
+        '2025-11-03'
+      );
+      expect(walesDates.find((d) => d.id === 'commemoration_of_all_the_faithful_departed')?.date).toEqual('2025-11-03');
     });
   });
 

--- a/rites/roman1969/__tests__/config.test.ts
+++ b/rites/roman1969/__tests__/config.test.ts
@@ -1,6 +1,12 @@
-import { Romcal } from '@src/rite-roman1969';
+import { AnchorException, ParticularConfig, Romcal, TemporalOverrides } from '@src/rite-roman1969';
 
-const { RomcalConfig, LiturgicalDayConfig } = Romcal;
+const { CalendarDef, RomcalConfig, LiturgicalDayConfig } = Romcal;
+
+const temporalOverridesFixture: TemporalOverrides = {
+  anchorExceptions: {
+    epiphany: [{ when: { dayOfWeek: 'saturday' }, then: { transferTo: 'sunday' } }],
+  },
+};
 
 describe('getConfig()', () => {
   test('should get general config if country does not have default configurations', async () => {
@@ -14,5 +20,110 @@ describe('getConfig()', () => {
     expect(epiphanyOnSunday).toBeFalsy();
     expect(corpusChristiOnSunday).toBeFalsy();
     expect(ascensionOnSunday).toBeFalsy();
+  });
+
+  test('should omit temporal overrides when none are configured', () => {
+    expect(new RomcalConfig().toObject()).not.toHaveProperty('temporalOverrides');
+  });
+
+  test('should return configured temporal overrides', () => {
+    expect(new RomcalConfig({ temporalOverrides: temporalOverridesFixture }).toObject().temporalOverrides).toEqual(
+      temporalOverridesFixture
+    );
+  });
+
+  test('should isolate temporal overrides from input and output mutations', () => {
+    const input = {
+      anchorExceptions: {
+        epiphany: [{ when: { dayOfWeek: 'saturday' }, then: { transferTo: 'sunday' } }],
+      },
+    } satisfies TemporalOverrides;
+    const config = new RomcalConfig({ temporalOverrides: input });
+
+    input.anchorExceptions.epiphany.length = 0;
+    expect(config.temporalOverrides?.anchorExceptions.epiphany).toHaveLength(1);
+
+    const outputExceptions = config.toObject().temporalOverrides?.anchorExceptions.epiphany as unknown as
+      AnchorException[] | undefined;
+    outputExceptions?.splice(0);
+
+    expect(config.temporalOverrides?.anchorExceptions.epiphany).toHaveLength(1);
+  });
+
+  test('should inherit temporal overrides from a parent calendar', () => {
+    class ParentCalendar extends CalendarDef {
+      particularConfig: ParticularConfig = { temporalOverrides: temporalOverridesFixture };
+    }
+
+    class ChildCalendar extends CalendarDef {
+      ParentCalendars = [ParentCalendar];
+    }
+
+    const config = new RomcalConfig(undefined, undefined, undefined, ChildCalendar);
+    expect(config.temporalOverrides).toEqual(temporalOverridesFixture);
+    expect(new LiturgicalDayConfig(config, 2024).dates.epiphany().toISOString()).toEqual('2024-01-07T00:00:00.000Z');
+  });
+
+  test('should preserve resolved temporal overrides when cloned', () => {
+    class ParentCalendar extends CalendarDef {
+      particularConfig: ParticularConfig = { temporalOverrides: temporalOverridesFixture };
+    }
+
+    class ChildCalendar extends CalendarDef {
+      ParentCalendars = [ParentCalendar];
+    }
+
+    const config = new RomcalConfig(undefined, undefined, undefined, ChildCalendar);
+    const clone = config.clone();
+
+    expect(clone.temporalOverrides).toEqual(temporalOverridesFixture);
+    expect(clone.temporalOverrides).not.toBe(config.temporalOverrides);
+    expect(clone.temporalOverrides?.anchorExceptions.epiphany).not.toBe(
+      config.temporalOverrides?.anchorExceptions.epiphany
+    );
+    expect(new LiturgicalDayConfig(clone, 2024).dates.epiphany().toISOString()).toEqual('2024-01-07T00:00:00.000Z');
+  });
+
+  test('should only remove inherited Epiphany exceptions for an explicit option', () => {
+    const otherAnchorException = {
+      when: { dayOfWeek: 'monday' },
+      then: { transferTo: 'sunday' },
+    } as const;
+    const inheritedOverrides = {
+      anchorExceptions: {
+        epiphany: temporalOverridesFixture.anchorExceptions.epiphany,
+        other_anchor: [otherAnchorException],
+      },
+    } as unknown as TemporalOverrides;
+
+    class ParentCalendar extends CalendarDef {
+      particularConfig: ParticularConfig = { temporalOverrides: inheritedOverrides };
+    }
+
+    class ChildCalendar extends CalendarDef {
+      ParentCalendars = [ParentCalendar];
+    }
+
+    const config = new RomcalConfig({ epiphanyOnSunday: false }, undefined, undefined, ChildCalendar);
+
+    expect(config.temporalOverrides).toEqual({
+      anchorExceptions: { other_anchor: [otherAnchorException] },
+    });
+  });
+
+  test('should replace inherited temporal overrides with the child calendar configuration', () => {
+    class ParentCalendar extends CalendarDef {
+      particularConfig: ParticularConfig = { temporalOverrides: temporalOverridesFixture };
+    }
+
+    class ChildCalendar extends CalendarDef {
+      ParentCalendars = [ParentCalendar];
+
+      particularConfig: ParticularConfig = { temporalOverrides: { anchorExceptions: {} } };
+    }
+
+    const config = new RomcalConfig(undefined, undefined, undefined, ChildCalendar);
+    expect(config.temporalOverrides).toEqual({ anchorExceptions: {} });
+    expect(new LiturgicalDayConfig(config, 2024).dates.epiphany().toISOString()).toEqual('2024-01-06T00:00:00.000Z');
   });
 });

--- a/rites/roman1969/__tests__/dates.test.ts
+++ b/rites/roman1969/__tests__/dates.test.ts
@@ -1,3 +1,4 @@
+import { England_En } from '@dist/rite-roman1969/bundles/england';
 import { France_Fr } from '@dist/rite-roman1969/bundles/france';
 import { UnitedStates_En } from '@dist/rite-roman1969/bundles/united-states';
 import { Romcal } from '@src/rite-roman1969';
@@ -564,6 +565,69 @@ describe('Testing specific liturgical date functions', () => {
   });
 
   describe('Epiphany of the Lord', () => {
+    describe('With configured temporal anchor exceptions', () => {
+      test('England transfers a Saturday or Monday Epiphany to the adjacent Sunday', () => {
+        const dates = new Romcal({ localizedCalendar: England_En }).dates();
+
+        expect(isSameDate(dates.epiphany(2024), getUtcDate(2024, 1, 7))).toBeTruthy();
+        expect(isSameDate(dates.epiphany(2025), getUtcDate(2025, 1, 5))).toBeTruthy();
+        expect(isSameDate(dates.epiphany(2021), getUtcDate(2021, 1, 6))).toBeTruthy();
+      });
+
+      test('an explicit argument remains independent from configured exceptions and cache order', () => {
+        const configuredFirst = new Romcal({ localizedCalendar: England_En }).dates(2024);
+        expect(isSameDate(configuredFirst.epiphany(2024), getUtcDate(2024, 1, 7))).toBeTruthy();
+        expect(isSameDate(configuredFirst.epiphany(2024, false), getUtcDate(2024, 1, 6))).toBeTruthy();
+        expect(isSameDate(configuredFirst.epiphany(2024), getUtcDate(2024, 1, 7))).toBeTruthy();
+
+        const explicitFirst = new Romcal({ localizedCalendar: England_En }).dates(2024);
+        expect(isSameDate(explicitFirst.epiphany(2024, false), getUtcDate(2024, 1, 6))).toBeTruthy();
+        expect(isSameDate(explicitFirst.epiphany(2024), getUtcDate(2024, 1, 7))).toBeTruthy();
+        expect(isSameDate(explicitFirst.epiphany(2024, false), getUtcDate(2024, 1, 6))).toBeTruthy();
+      });
+
+      test('an explicit epiphanyOnSunday option preserves its historical meaning', () => {
+        const dates = new Romcal({ localizedCalendar: England_En, epiphanyOnSunday: false }).dates(2024);
+        expect(isSameDate(dates.epiphany(), getUtcDate(2024, 1, 6))).toBeTruthy();
+      });
+
+      test('an explicit true epiphanyOnSunday option uses the general Sunday rule', () => {
+        const dates = new Romcal({ localizedCalendar: England_En, epiphanyOnSunday: true }).dates(2026);
+        expect(isSameDate(dates.epiphany(), getUtcDate(2026, 1, 4))).toBeTruthy();
+      });
+
+      test('keeps Epiphany unchanged when January 6 is already a Sunday', () => {
+        const dates = new Romcal({ localizedCalendar: England_En }).dates(2030);
+        expect(isSameDate(dates.epiphany(), getUtcDate(2030, 1, 6))).toBeTruthy();
+      });
+
+      test('uses an explicit Epiphany mode consistently for Ordinary Time dates', () => {
+        const dates = new Romcal({ epiphanyOnSunday: false }).dates(2024);
+        expect(isSameDate(dates.dateOfOrdinaryTime(1, 2, 2024, true)!, getUtcDate(2024, 1, 15))).toBeTruthy();
+      });
+
+      test('an explicit empty temporal override clears the calendar exceptions', () => {
+        const dates = new Romcal({
+          localizedCalendar: England_En,
+          temporalOverrides: { anchorExceptions: {} },
+        }).dates(2024);
+        expect(isSameDate(dates.epiphany(), getUtcDate(2024, 1, 6))).toBeTruthy();
+      });
+
+      test('explicit temporal overrides take precedence over epiphanyOnSunday', () => {
+        const dates = new Romcal({
+          localizedCalendar: England_En,
+          epiphanyOnSunday: false,
+          temporalOverrides: {
+            anchorExceptions: {
+              epiphany: [{ when: { dayOfWeek: 'saturday' }, then: { transferTo: 'sunday' } }],
+            },
+          },
+        }).dates(2024);
+        expect(isSameDate(dates.epiphany(), getUtcDate(2024, 1, 7))).toBeTruthy();
+      });
+    });
+
     describe('If Epiphany of the Lord is always celebrated on Jan 6', () => {
       test('Epiphany of the Lord in 2001 will be on a Saturday', () => {
         expect(new Romcal().dates().epiphany(2001, false).getUTCDay()).toEqual(6);

--- a/rites/roman1969/build/bundle.ts
+++ b/rites/roman1969/build/bundle.ts
@@ -191,6 +191,7 @@ export const RomcalBundler = (): void => {
           epiphanyOnSunday: builder.config.epiphanyOnSunday,
           ascensionOnSunday: builder.config.ascensionOnSunday,
           corpusChristiOnSunday: builder.config.corpusChristiOnSunday,
+          ...(builder.config.temporalOverrides ? { temporalOverrides: builder.config.temporalOverrides } : {}),
         },
         inputs: definitions,
         martyrology,

--- a/rites/roman1969/src/calendars/countries/england/index.ts
+++ b/rites/roman1969/src/calendars/countries/england/index.ts
@@ -12,9 +12,20 @@ import { England_ArundelBrighton } from './diocese-of-arundel-and-brighton';
 export class England extends CalendarDef {
   ParentCalendars = [Europe];
 
-  // src: https://www.liturgyoffice.org.uk/Calendar/2027/Ordo-2027.pdf
+  // src:
+  // - https://www.liturgyoffice.org.uk/Calendar/Info/Holydays-Decree-CDW.pdf
+  // - https://www.liturgyoffice.org.uk/Calendar/Holydays.shtml
+  // - https://www.liturgyoffice.org.uk/Calendar/2027/Ordo-2027.pdf
   particularConfig: ParticularConfig = {
     epiphanyOnSunday: false,
+    temporalOverrides: {
+      anchorExceptions: {
+        epiphany: [
+          { when: { dayOfWeek: 'saturday' }, then: { transferTo: 'sunday' } },
+          { when: { dayOfWeek: 'monday' }, then: { transferTo: 'sunday' } },
+        ],
+      },
+    },
     ascensionOnSunday: false,
     corpusChristiOnSunday: true,
   };
@@ -265,17 +276,27 @@ export class England extends CalendarDef {
       dateDef: { month: 11, date: 30 },
     },
 
-    // In England and Wales when All Saints (1 November) falls on a Saturday
-    // and is transferred to Sunday, All Souls is transferred to Monday 3 November.
+    // src:
+    // - https://www.liturgyoffice.org.uk/Calendar/Holydays.shtml
+    // - https://www.liturgyoffice.org.uk/Calendar/2024/Calendar-2024.pdf
+    // In England and Wales when All Saints (1 November) falls on a Saturday or Monday,
+    // it is transferred to the adjacent Sunday. If that Sunday is 2 November,
+    // All Souls is transferred to Monday 3 November.
     // Like Ash Wednesday, All Souls is, technically, without rank.
     // However, in countries (not England & Wales) where it falls
     // on a Sunday it replaces the Sunday.
     all_saints: {
       dateDef: { month: 11, date: 1 },
-      dateExceptions: {
-        ifIsDayOfWeek: 6, // if is a Saturday
-        setDate: { addDay: 1 },
-      },
+      dateExceptions: [
+        {
+          ifIsDayOfWeek: 1, // if is a Monday
+          setDate: { subtractDay: 1 },
+        },
+        {
+          ifIsDayOfWeek: 6, // if is a Saturday
+          setDate: { addDay: 1 },
+        },
+      ],
     },
 
     commemoration_of_all_the_faithful_departed: {

--- a/rites/roman1969/src/calendars/countries/wales/index.ts
+++ b/rites/roman1969/src/calendars/countries/wales/index.ts
@@ -8,9 +8,20 @@ import { Europe } from '../../regions/europe';
 export class Wales extends CalendarDef {
   ParentCalendars = [Europe];
 
-  // src: https://www.liturgyoffice.org.uk/Calendar/2027/Ordo-2027.pdf
+  // src:
+  // - https://www.liturgyoffice.org.uk/Calendar/Info/Holydays-Decree-CDW.pdf
+  // - https://www.liturgyoffice.org.uk/Calendar/Holydays.shtml
+  // - https://www.liturgyoffice.org.uk/Calendar/2027/Ordo-2027.pdf
   particularConfig: ParticularConfig = {
     epiphanyOnSunday: false,
+    temporalOverrides: {
+      anchorExceptions: {
+        epiphany: [
+          { when: { dayOfWeek: 'saturday' }, then: { transferTo: 'sunday' } },
+          { when: { dayOfWeek: 'monday' }, then: { transferTo: 'sunday' } },
+        ],
+      },
+    },
     ascensionOnSunday: false,
     corpusChristiOnSunday: true,
   };
@@ -105,17 +116,27 @@ export class Wales extends CalendarDef {
       dateDef: { month: 11, date: 6 },
     },
 
-    // In England and Wales when All Saints (1 November) falls on a Saturday
-    // and is transferred to Sunday, All Souls is transferred to Monday 3 November.
+    // src:
+    // - https://www.liturgyoffice.org.uk/Calendar/Holydays.shtml
+    // - https://www.liturgyoffice.org.uk/Calendar/2024/Calendar-2024.pdf
+    // In England and Wales when All Saints (1 November) falls on a Saturday or Monday,
+    // it is transferred to the adjacent Sunday. If that Sunday is 2 November,
+    // All Souls is transferred to Monday 3 November.
     // Like Ash Wednesday, All Souls is, technically, without rank.
     // However, in countries (not England & Wales) where it falls
     // on a Sunday it replaces the Sunday.
     all_saints: {
       dateDef: { month: 11, date: 1 },
-      dateExceptions: {
-        ifIsDayOfWeek: 6, // if is a Saturday
-        setDate: { addDay: 1 },
-      },
+      dateExceptions: [
+        {
+          ifIsDayOfWeek: 1, // if is a Monday
+          setDate: { subtractDay: 1 },
+        },
+        {
+          ifIsDayOfWeek: 6, // if is a Saturday
+          setDate: { addDay: 1 },
+        },
+      ],
     },
 
     commemoration_of_all_the_faithful_departed: {

--- a/rites/roman1969/src/index.ts
+++ b/rites/roman1969/src/index.ts
@@ -56,7 +56,15 @@ import {
   ParticularConfig,
 } from './types/calendar-def';
 import { Id } from './types/common';
-import { CalendarScope, RomcalConfigInput, RomcalConfigOutput } from './types/config';
+import {
+  AnchorException,
+  AnchorTransferTarget,
+  CalendarScope,
+  RomcalConfigInput,
+  RomcalConfigOutput,
+  ShiftableAnchor,
+  TemporalOverrides,
+} from './types/config';
 import { BaseCyclesMetadata, PartialCyclesDef, PlainCyclesMetadata } from './types/cycles-metadata';
 import {
   BaseLiturgicalDay,
@@ -472,8 +480,12 @@ export {
   RomcalBundleObject,
   RomcalCalendarMetadata,
   // types/config.ts
+  AnchorException,
+  AnchorTransferTarget,
   RomcalConfigInput,
   RomcalConfigOutput,
+  ShiftableAnchor,
+  TemporalOverrides,
   RomcalTitles,
   // types/martyrology.ts
   SaintCount,

--- a/rites/roman1969/src/models/calendar-def.ts
+++ b/rites/roman1969/src/models/calendar-def.ts
@@ -9,6 +9,7 @@ import { Id } from '../types/common';
 import { RomcalConfigInput } from '../types/config';
 import { LiturgicalDayBundleInput } from '../types/liturgical-day';
 import { Dates } from '../utils/dates';
+import { cloneTemporalOverrides, omitTemporalOverrideAnchor } from '../utils/temporal-overrides';
 
 import { RomcalConfig } from './config';
 import { LiturgicalDayDef } from './liturgical-day-def';
@@ -72,6 +73,17 @@ export class CalendarDef implements BaseCalendarDef {
 
     this.#config.epiphanyOnSunday =
       input?.epiphanyOnSunday ?? this.particularConfig?.epiphanyOnSunday ?? this.#config.epiphanyOnSunday;
+
+    if (input?.temporalOverrides !== undefined) {
+      this.#config.temporalOverrides = cloneTemporalOverrides(input.temporalOverrides);
+    } else if (input?.epiphanyOnSunday !== undefined) {
+      this.#config.temporalOverrides = omitTemporalOverrideAnchor(
+        this.particularConfig?.temporalOverrides ?? this.#config.temporalOverrides,
+        'epiphany'
+      );
+    } else if (this.particularConfig?.temporalOverrides !== undefined) {
+      this.#config.temporalOverrides = cloneTemporalOverrides(this.particularConfig.temporalOverrides);
+    }
 
     this.#config.ascensionOnSunday =
       input?.ascensionOnSunday ?? this.particularConfig?.ascensionOnSunday ?? this.#config.ascensionOnSunday;

--- a/rites/roman1969/src/models/config.ts
+++ b/rites/roman1969/src/models/config.ts
@@ -13,6 +13,7 @@ import {
   OutputOptions,
   RomcalConfigInput,
   RomcalConfigOutput,
+  TemporalOverrides,
 } from '../types/config';
 import { BaseCyclesMetadata } from '../types/cycles-metadata';
 import { Locale } from '../types/locale';
@@ -20,6 +21,7 @@ import { MartyrologyCatalog } from '../types/martyrology';
 import { Dates } from '../utils/dates';
 import { toRomanNumber } from '../utils/numbers';
 import { sanitizeLocaleId } from '../utils/string';
+import { cloneTemporalOverrides, omitTemporalOverrideAnchor } from '../utils/temporal-overrides';
 
 import { CalendarDef } from './calendar-def';
 
@@ -40,6 +42,8 @@ export class RomcalConfig implements IRomcalConfig {
   corpusChristiOnSunday: boolean;
 
   ascensionOnSunday: boolean;
+
+  temporalOverrides?: TemporalOverrides;
 
   elevatedMemorialIds: string[] = [];
 
@@ -65,7 +69,10 @@ export class RomcalConfig implements IRomcalConfig {
    * Clone the RomcalConfig object
    */
   clone(): RomcalConfig {
-    return new RomcalConfig({ ...this.#input });
+    return new RomcalConfig({
+      ...this.#input,
+      temporalOverrides: cloneTemporalOverrides(this.temporalOverrides),
+    });
   }
 
   /**
@@ -81,7 +88,12 @@ export class RomcalConfig implements IRomcalConfig {
     locale?: Locale,
     ParticularCalendar?: typeof CalendarDef
   ) {
-    this.#input = config || {};
+    this.#input = config
+      ? {
+          ...config,
+          temporalOverrides: cloneTemporalOverrides(config.temporalOverrides),
+        }
+      : {};
 
     if (config?.localizedCalendar) {
       this.localizedCalendar = config.localizedCalendar;
@@ -96,6 +108,16 @@ export class RomcalConfig implements IRomcalConfig {
       config?.corpusChristiOnSunday ?? this.localizedCalendar?.particularConfig.corpusChristiOnSunday ?? true;
     this.ascensionOnSunday =
       config?.ascensionOnSunday ?? this.localizedCalendar?.particularConfig.ascensionOnSunday ?? false;
+    if (config?.temporalOverrides !== undefined) {
+      this.temporalOverrides = cloneTemporalOverrides(config.temporalOverrides);
+    } else if (config?.epiphanyOnSunday !== undefined) {
+      this.temporalOverrides = omitTemporalOverrideAnchor(
+        this.localizedCalendar?.particularConfig.temporalOverrides,
+        'epiphany'
+      );
+    } else {
+      this.temporalOverrides = cloneTemporalOverrides(this.localizedCalendar?.particularConfig.temporalOverrides);
+    }
 
     this.elevatedMemorialIds = config?.elevatedMemorialIds ?? [];
 
@@ -209,6 +231,7 @@ export class RomcalConfig implements IRomcalConfig {
       epiphanyOnSunday: this.epiphanyOnSunday,
       corpusChristiOnSunday: this.corpusChristiOnSunday,
       ascensionOnSunday: this.ascensionOnSunday,
+      ...(this.temporalOverrides ? { temporalOverrides: cloneTemporalOverrides(this.temporalOverrides) } : {}),
       elevatedMemorialIds: this.elevatedMemorialIds,
       localeId: this.localeId,
       calendarName: this.calendarName,

--- a/rites/roman1969/src/types/calendar-def.ts
+++ b/rites/roman1969/src/types/calendar-def.ts
@@ -10,7 +10,10 @@ import { LiturgicalDayBundleInput, LiturgicalDayInput } from './liturgical-day';
  * Specific and proper configuration of a particular calendar
  */
 export type ParticularConfig = Partial<
-  Pick<RomcalConfig, 'ascensionOnSunday' | 'epiphanyOnSunday' | 'corpusChristiOnSunday' | 'easterCalculationType'>
+  Pick<
+    RomcalConfig,
+    'ascensionOnSunday' | 'epiphanyOnSunday' | 'corpusChristiOnSunday' | 'easterCalculationType' | 'temporalOverrides'
+  >
 >;
 
 /**

--- a/rites/roman1969/src/types/config.ts
+++ b/rites/roman1969/src/types/config.ts
@@ -1,8 +1,39 @@
 import { i18n } from 'i18next';
 
+import { Weekday } from '../constants/weekdays';
+
 import { RomcalBundleObject } from './bundle';
 import { CalendarDefInstance } from './calendar-def';
 import { Id } from './common';
+
+/**
+ * Temporal dates that can receive calendar-specific exception rules.
+ */
+export type ShiftableAnchor = 'epiphany';
+
+/**
+ * Calendar target supported when an anchor exception is applied.
+ */
+export type AnchorTransferTarget = 'sunday';
+
+/**
+ * Moves an anchor when its calculated date falls on the configured weekday.
+ */
+export interface AnchorException {
+  readonly when: {
+    readonly dayOfWeek: Weekday;
+  };
+  readonly then: {
+    readonly transferTo: AnchorTransferTarget;
+  };
+}
+
+/**
+ * Calendar-specific exceptions applied after temporal anchor dates are calculated.
+ */
+export interface TemporalOverrides {
+  readonly anchorExceptions: Partial<Record<ShiftableAnchor, readonly AnchorException[]>>;
+}
 
 /**
  * The configuration object that is passed either to the [[Calendar.calendarFor]]
@@ -13,6 +44,11 @@ export interface BaseRomcalConfig {
    * The localized calendar bundle object.
    */
   readonly localizedCalendar?: RomcalBundleObject;
+
+  /**
+   * Exceptions applied to dates calculated from temporal anchors.
+   */
+  readonly temporalOverrides?: TemporalOverrides;
 
   /**
    * If `false`, fixes Epiphany on January 6th. Usually, Epiphany will be set to a
@@ -108,7 +144,10 @@ export type RomcalConfigInput = Omit<Partial<BaseRomcalConfig>, 'localeId' | 'ca
 /**
  * Output object of the romcal config.
  */
-export type RomcalConfigOutput = Required<Omit<BaseRomcalConfig, 'localizedCalendar' | 'calendarsDef'>>;
+export type RomcalConfigOutput = Required<
+  Omit<BaseRomcalConfig, 'localizedCalendar' | 'calendarsDef' | 'temporalOverrides'>
+> &
+  Pick<BaseRomcalConfig, 'temporalOverrides'>;
 
 export type CalendarScope = 'gregorian' | 'liturgical';
 

--- a/rites/roman1969/src/utils/dates.ts
+++ b/rites/roman1969/src/utils/dates.ts
@@ -2,8 +2,9 @@ import { calculateGregorianEasterDate, calculateJulianEasterDateToGregorianDate 
 import { calculateLunarNewYear } from '@internal/lunar-new-year';
 
 import { Season } from '../constants/seasons';
+import { WEEKDAYS } from '../constants/weekdays';
 import { RomcalConfig } from '../models/config';
-import { EasterCalculationType } from '../types/config';
+import { EasterCalculationType, ShiftableAnchor } from '../types/config';
 
 const { isNaN } = Number;
 
@@ -108,6 +109,29 @@ export class Dates {
     this.#config = config;
     this.#year = year;
     this.#isLiturgicalYear = this.#config.scope === 'liturgical';
+  }
+
+  #epiphanyModeCacheKey(year: number, epiphanyOnSunday?: boolean): string {
+    const mode = epiphanyOnSunday === undefined ? 'configured' : `explicit_${epiphanyOnSunday.toString()}`;
+    return `${year}_${mode}`;
+  }
+
+  #applyAnchorExceptions(anchor: ShiftableAnchor, date: Date): Date {
+    const exception = this.#config.temporalOverrides?.anchorExceptions[anchor]?.find(
+      ({ when }) => when.dayOfWeek === WEEKDAYS[date.getUTCDay()]
+    );
+
+    if (!exception) return date;
+
+    if (exception.then.transferTo === 'sunday') {
+      const daysAfterSunday = date.getUTCDay();
+      const daysBeforeSunday = 7 - daysAfterSunday;
+      return daysAfterSunday <= daysBeforeSunday
+        ? subtractsDays(date, daysAfterSunday)
+        : addDays(date, daysBeforeSunday);
+    }
+
+    return date;
   }
 
   /**
@@ -313,13 +337,13 @@ export class Dates {
    * Presentation of the Lord, 40 days after Dec. 25) (Candlemass).*
    *
    * @param year Gregorian year
-   * @param epiphanyOnSunday Is Epiphany is fixed on a Sunday
+   * @param epiphanyOnSunday Whether Epiphany follows the Sunday rule. When omitted, calendar anchor exceptions apply.
    */
   allDatesOfChristmasTime = (
     year = this.#isLiturgicalYear ? this.#year - 1 : this.#year,
-    epiphanyOnSunday = this.#config.epiphanyOnSunday
+    epiphanyOnSunday?: boolean
   ): Date[] => {
-    const id = year + epiphanyOnSunday.toString();
+    const id = this.#epiphanyModeCacheKey(year, epiphanyOnSunday);
     if (this.#allDatesOfChristmasTime[id]) return this.#allDatesOfChristmasTime[id];
     const start = this.christmas(year);
     const end = this.baptismOfTheLord(year + 1, epiphanyOnSunday);
@@ -333,14 +357,16 @@ export class Dates {
    * which is not the Epiphany or the Baptism of the Lord.
    * This can occur only when Epiphany is celebrated the 6 January.
    * @param year Gregorian year
-   * @param epiphanyOnSunday Is Epiphany is fixed on a Sunday
+   * @param epiphanyOnSunday Whether Epiphany follows the Sunday rule. When omitted, calendar anchor exceptions apply.
    */
-  secondSundayAfterChristmas = (year = this.#year, epiphanyOnSunday = this.#config.epiphanyOnSunday): Date | null => {
-    const id = year + epiphanyOnSunday.toString();
+  secondSundayAfterChristmas = (year = this.#year, epiphanyOnSunday?: boolean): Date | null => {
+    const id = this.#epiphanyModeCacheKey(year, epiphanyOnSunday);
     if (this.#secondSundayAfterChristmas[id] !== undefined) {
       return this.#secondSundayAfterChristmas[id];
     }
-    if (epiphanyOnSunday) return (this.#secondSundayAfterChristmas[id] = null);
+    if (epiphanyOnSunday ?? this.#config.epiphanyOnSunday) {
+      return (this.#secondSundayAfterChristmas[id] = null);
+    }
     const date =
       this.allDatesBeforeEpiphany(year, epiphanyOnSunday).find((d) => d.getUTCDay() === 0) ??
       this.allDatesAfterEpiphany(year, epiphanyOnSunday).find((d) => d.getUTCDay() === 0);
@@ -352,10 +378,10 @@ export class Dates {
   /**
    * Get all the date before Epiphany (and from January 2)
    * @param year Gregorian year
-   * @param epiphanyOnSunday Is Epiphany is fixed on a Sunday
+   * @param epiphanyOnSunday Whether Epiphany follows the Sunday rule. When omitted, calendar anchor exceptions apply.
    */
-  allDatesBeforeEpiphany = (year = this.#year, epiphanyOnSunday = this.#config.epiphanyOnSunday): Date[] => {
-    const id = year + epiphanyOnSunday.toString();
+  allDatesBeforeEpiphany = (year = this.#year, epiphanyOnSunday?: boolean): Date[] => {
+    const id = this.#epiphanyModeCacheKey(year, epiphanyOnSunday);
     if (this.#allDatesBeforeEpiphany[id]) return this.#allDatesBeforeEpiphany[id];
     const start = addDays(this.maryMotherOfGod(year), 1);
     const epiphany = this.epiphany(year, epiphanyOnSunday);
@@ -373,14 +399,10 @@ export class Dates {
    * Get the date of a weekday before Epiphany (and from January 2)
    * @param day Nth day of month
    * @param year Gregorian year
-   * @param epiphanyOnSunday Is Epiphany is fixed on a Sunday
+   * @param epiphanyOnSunday Whether Epiphany follows the Sunday rule. When omitted, calendar anchor exceptions apply.
    */
-  weekdayBeforeEpiphany = (
-    day: number,
-    year = this.#year,
-    epiphanyOnSunday = this.#config.epiphanyOnSunday
-  ): Date | null => {
-    const id = `${day}_${year}_${epiphanyOnSunday.toString()}`;
+  weekdayBeforeEpiphany = (day: number, year = this.#year, epiphanyOnSunday?: boolean): Date | null => {
+    const id = `${day}_${this.#epiphanyModeCacheKey(year, epiphanyOnSunday)}`;
     if (this.#weekdayBeforeEpiphany[id] !== undefined) return this.#weekdayBeforeEpiphany[id];
     if (day < 2 || day > 8) return (this.#weekdayBeforeEpiphany[id] = null);
     return (this.#weekdayBeforeEpiphany[id] =
@@ -398,17 +420,17 @@ export class Dates {
    * - *Epiphany is always celebrated on Jan 6.
    *
    * @param year Gregorian year
-   * @param epiphanyOnSunday Is Epiphany is fixed on a Sunday
+   * @param epiphanyOnSunday Whether Epiphany follows the Sunday rule. When omitted, calendar anchor exceptions apply.
    */
-  epiphany = (year = this.#year, epiphanyOnSunday = this.#config.epiphanyOnSunday): Date => {
-    const id = year + epiphanyOnSunday.toString();
+  epiphany = (year = this.#year, epiphanyOnSunday?: boolean): Date => {
+    const id = this.#epiphanyModeCacheKey(year, epiphanyOnSunday);
     if (this.#epiphany[id]) return this.#epiphany[id];
 
     // Get the first day of the year
     const firstDay = getUtcDate(year, 1, 1);
     let date = getUtcDate(year, 1, 6);
 
-    if (epiphanyOnSunday) {
+    if (epiphanyOnSunday ?? this.#config.epiphanyOnSunday) {
       switch (firstDay.getUTCDay()) {
         // If first day of the year is a Saturday, Mary Mother of God is on that day
         // and Epiphany is on the next day
@@ -428,6 +450,8 @@ export class Dates {
       }
     }
 
+    if (epiphanyOnSunday === undefined) date = this.#applyAnchorExceptions('epiphany', date);
+
     return (this.#epiphany[id] = date);
   };
 
@@ -436,10 +460,10 @@ export class Dates {
   /**
    * Get all the dates after Epiphany, until the day before the Baptism of the Lord.
    * @param year Gregorian year
-   * @param epiphanyOnSunday Is Epiphany is fixed on a Sunday
+   * @param epiphanyOnSunday Whether Epiphany follows the Sunday rule. When omitted, calendar anchor exceptions apply.
    */
-  allDatesAfterEpiphany = (year = this.#year, epiphanyOnSunday = this.#config.epiphanyOnSunday): Date[] => {
-    const id = year + epiphanyOnSunday.toString();
+  allDatesAfterEpiphany = (year = this.#year, epiphanyOnSunday?: boolean): Date[] => {
+    const id = this.#epiphanyModeCacheKey(year, epiphanyOnSunday);
     if (this.#allDatesAfterEpiphany[id]) return this.#allDatesAfterEpiphany[id];
     const start = addDays(this.epiphany(year, epiphanyOnSunday), 1);
     const baptismOfTheLord = this.baptismOfTheLord(year, epiphanyOnSunday);
@@ -457,14 +481,10 @@ export class Dates {
    * Get the date of a weekday after Epiphany (and before the Baptism of the Lord)
    * @param dow Day of week
    * @param year Gregorian year
-   * @param epiphanyOnSunday Is Epiphany is fixed on a Sunday
+   * @param epiphanyOnSunday Whether Epiphany follows the Sunday rule. When omitted, calendar anchor exceptions apply.
    */
-  weekdayAfterEpiphany = (
-    dow: number,
-    year = this.#year,
-    epiphanyOnSunday = this.#config.epiphanyOnSunday
-  ): Date | null => {
-    const id = `${dow}_${year}_${epiphanyOnSunday.toString()}`;
+  weekdayAfterEpiphany = (dow: number, year = this.#year, epiphanyOnSunday?: boolean): Date | null => {
+    const id = `${dow}_${this.#epiphanyModeCacheKey(year, epiphanyOnSunday)}`;
     if (this.#weekdayAfterEpiphany[id] !== undefined) return this.#weekdayAfterEpiphany[id];
     if (dow < 1 || dow > 6) return (this.#weekdayAfterEpiphany[id] = null);
     return (this.#weekdayAfterEpiphany[id] =
@@ -755,10 +775,10 @@ export class Dates {
   /**
    * Get all the dates occurring in Ordinary Time
    * @param year Gregorian year
-   * @param epiphanyOnSunday Is Epiphany is fixed on a Sunday
+   * @param epiphanyOnSunday Whether Epiphany follows the Sunday rule. When omitted, calendar anchor exceptions apply.
    */
-  allDatesOfOrdinaryTime = (year = this.#year, epiphanyOnSunday = this.#config.epiphanyOnSunday): Date[] => {
-    const id = year + epiphanyOnSunday.toString();
+  allDatesOfOrdinaryTime = (year = this.#year, epiphanyOnSunday?: boolean): Date[] => {
+    const id = this.#epiphanyModeCacheKey(year, epiphanyOnSunday);
     if (this.#allDatesOfOrdinaryTime[id]) return this.#allDatesOfOrdinaryTime[id];
     return (this.#allDatesOfOrdinaryTime[id] = [
       ...this.allDatesOfEarlyOrdinaryTime(year, epiphanyOnSunday),
@@ -777,10 +797,10 @@ export class Dates {
    * the day before Ash Wednesday.*
    *
    * @param year Gregorian year
-   * @param epiphanyOnSunday Is Epiphany is fixed on a Sunday
+   * @param epiphanyOnSunday Whether Epiphany follows the Sunday rule. When omitted, calendar anchor exceptions apply.
    */
-  allDatesOfEarlyOrdinaryTime = (year = this.#year, epiphanyOnSunday = this.#config.epiphanyOnSunday): Date[] => {
-    const id = year + epiphanyOnSunday.toString();
+  allDatesOfEarlyOrdinaryTime = (year = this.#year, epiphanyOnSunday?: boolean): Date[] => {
+    const id = this.#epiphanyModeCacheKey(year, epiphanyOnSunday);
     if (this.#allDatesOfEarlyOrdinaryTime[id]) return this.#allDatesOfEarlyOrdinaryTime[id];
     const start = addDays(this.baptismOfTheLord(year, epiphanyOnSunday), 1);
     const end = subtractsDays(this.ashWednesday(year), 1);
@@ -843,19 +863,14 @@ export class Dates {
 
   #christTheKingSunday: Record<string, Date> = {};
 
-  dateOfOrdinaryTime = (
-    dow: number,
-    week: number,
-    year = this.#year,
-    epiphanyOnSunday = this.#config.epiphanyOnSunday
-  ): Date | null => {
-    const id = year + epiphanyOnSunday.toString();
+  dateOfOrdinaryTime = (dow: number, week: number, year = this.#year, epiphanyOnSunday?: boolean): Date | null => {
+    const id = this.#epiphanyModeCacheKey(year, epiphanyOnSunday);
 
     if (this.#dateOfOrdinaryTime[id] === undefined) {
       const early = this.allDatesOfEarlyOrdinaryTime(year, epiphanyOnSunday);
       const late = this.allDatesOfLateOrdinaryTime(year);
       const lateOrdinaryStartWeekCount = Math.floor(35 - (late.length + 1) / 7);
-      const baptismOfTheLordIsMonday = this.baptismOfTheLord(year).getUTCDay() === 1;
+      const baptismOfTheLordIsMonday = this.baptismOfTheLord(year, epiphanyOnSunday).getUTCDay() === 1;
 
       const trinitySunday = this.trinitySunday(year).getTime();
       const corpusChristi = this.corpusChristi(year).getTime();
@@ -1180,10 +1195,10 @@ export class Dates {
    * Sunday following The Epiphany of Our Lord (6 January).*
    *
    * @param year Gregorian year
-   * @param epiphanyOnSunday Is Epiphany is fixed on a Sunday
+   * @param epiphanyOnSunday Whether Epiphany follows the Sunday rule. When omitted, calendar anchor exceptions apply.
    */
-  baptismOfTheLord = (year = this.#year, epiphanyOnSunday = this.#config.epiphanyOnSunday): Date => {
-    const id = year + epiphanyOnSunday.toString();
+  baptismOfTheLord = (year = this.#year, epiphanyOnSunday?: boolean): Date => {
+    const id = this.#epiphanyModeCacheKey(year, epiphanyOnSunday);
     if (this.#baptismOfTheLord[id]) return this.#baptismOfTheLord[id];
 
     const epiphany = this.epiphany(year, epiphanyOnSunday);
@@ -1191,12 +1206,12 @@ export class Dates {
     // If Epiphany is celebrated on Jan. 6
     // the Baptism of the Lord occurs on the Sunday following Jan. 6.
     if (epiphany.getUTCDate() === 6) {
-      return startOfWeek(addDays(epiphany, 7));
+      return (this.#baptismOfTheLord[id] = startOfWeek(addDays(epiphany, 7)));
     }
     // If Epiphany occurs on Sunday Jan. 7 or Sunday Jan. 8,
     //  then the Baptism of the Lord is the next day (Monday)
     if ((epiphany.getUTCDay() === 0 && epiphany.getUTCDate() === 7) || epiphany.getUTCDate() === 8) {
-      return addDays(epiphany, 1);
+      return (this.#baptismOfTheLord[id] = addDays(epiphany, 1));
     }
     // If Epiphany occurs before Jan. 6, the Sunday
     // following Epiphany is the Baptism of the Lord.

--- a/rites/roman1969/src/utils/temporal-overrides.ts
+++ b/rites/roman1969/src/utils/temporal-overrides.ts
@@ -1,0 +1,32 @@
+import { ShiftableAnchor, TemporalOverrides } from '../types/config';
+
+/** Creates a deep copy of temporal override rules. */
+export const cloneTemporalOverrides = (temporalOverrides?: TemporalOverrides): TemporalOverrides | undefined => {
+  if (!temporalOverrides) return undefined;
+
+  const anchorExceptions: TemporalOverrides['anchorExceptions'] = {};
+
+  (Object.keys(temporalOverrides.anchorExceptions) as ShiftableAnchor[]).forEach((anchor) => {
+    const exceptions = temporalOverrides.anchorExceptions[anchor];
+    if (!exceptions) return;
+
+    anchorExceptions[anchor] = exceptions.map((exception) => ({
+      then: { ...exception.then },
+      when: { ...exception.when },
+    }));
+  });
+
+  return { anchorExceptions };
+};
+
+/** Returns a copy without the exceptions configured for the given anchor. */
+export const omitTemporalOverrideAnchor = (
+  temporalOverrides: TemporalOverrides | undefined,
+  anchor: ShiftableAnchor
+): TemporalOverrides | undefined => {
+  const result = cloneTemporalOverrides(temporalOverrides);
+  if (!result) return undefined;
+
+  delete result.anchorExceptions[anchor];
+  return Object.keys(result.anchorExceptions).length > 0 ? result : undefined;
+};


### PR DESCRIPTION
## What is the purpose of this pull request?

Add support for the transfer rules used by the England and Wales calendars:

- transfer Epiphany to the adjacent Sunday when January 6 falls on Saturday or Monday;
- transfer All Saints to the adjacent Sunday under the same conditions;
- preserve the behavior of explicit `epiphanyOnSunday` overrides.

This also introduces configurable temporal anchor exceptions that can be inherited by child calendars.

Closes #185.

## Concept

- Calendar Definition
- Date calculation
- Configuration
- Documentation

Rather than introducing another calendar-specific boolean, this PR models the behavior as declarative temporal anchor exceptions. This makes the current rule explicit while providing an extension point for similar transfer rules in other jurisdictions, without expanding the public configuration with additional one-off flags.

## Liturgical sources

The implemented transfer rules follow the norms published for England and Wales:

- [Decree of the Congregation for Divine Worship and the Discipline of the Sacraments](https://www.liturgyoffice.org.uk/Calendar/Info/Holydays-Decree-CDW.pdf): Epiphany is observed on January 6, except when it falls on Saturday or Monday, in which case it is transferred to the following or preceding Sunday respectively.
- [Liturgy Office - Holydays of Obligation](https://www.liturgyoffice.org.uk/Calendar/Holydays.shtml): documents the Saturday/Monday transfer rule for the relevant holydays in England and Wales, including All Saints.
- [Official Liturgical Calendar 2024](https://www.liturgyoffice.org.uk/Calendar/2024/Calendar-2024.pdf): confirms the concrete 2024 and 2025 dates covered by the tests.

## Example code

England and Wales bundles apply their transfer rules automatically:

```typescript
import Romcal from 'romcal';
import { England_En } from '@romcal/calendar.england';

const calendar = await new Romcal({
  localizedCalendar: England_En,
}).generateCalendar(2024);
```

Temporal anchor exceptions can also be configured explicitly:

```typescript
const calendar = await new Romcal({
  temporalOverrides: {
    anchorExceptions: {
      epiphany: [
        {
          when: { dayOfWeek: 'saturday' },
          then: { transferTo: 'sunday' },
        },
      ],
    },
  },
}).generateCalendar(2024);
```

---

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](../docs/CODE_OF_CONDUCT.md).
