### PR TITLE
feat(package): scaffold @internal/builder

### DIFF
--- a/.config/eslint.config.mjs
+++ b/.config/eslint.config.mjs
@@ -195,6 +195,7 @@ export default [
         parser: '@typescript-eslint/parser',
         project: [
           './tsconfig.base.json',
+          './packages/builder/tsconfig.json',
           './packages/easter/tsconfig.json',
           './packages/lunar-new-year/tsconfig.json',
           './rites/roman1962/tsconfig.json',
@@ -226,6 +227,7 @@ export default [
         parser: '@typescript-eslint/parser',
         project: [
           './tsconfig.base.json',
+          './packages/builder/tsconfig.json',
           './packages/easter/tsconfig.json',
           './packages/lunar-new-year/tsconfig.json',
           './rites/roman1962/tsconfig.json',
@@ -288,6 +290,25 @@ export default [
       'import/no-default-export': 'off',
       'import/no-extraneous-dependencies': 'off',
       'no-console': 'off',
+    },
+  }),
+  // The builder is development tooling that runs in Node. A rite's src is bundled
+  // into cjs, esm and iife for consumers, so importing the builder from there would
+  // pull the whole toolchain into a published artifact.
+  ...tseslint.config({
+    files: ['rites/*/src/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@internal/builder', '@internal/builder/*'],
+              message: 'The builder is build-time tooling. Importing it from a rite would bundle it for consumers.',
+            },
+          ],
+        },
+      ],
     },
   }),
   ...tseslint.config({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1850,6 +1850,10 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@internal/builder": {
+      "resolved": "packages/builder",
+      "link": true
+    },
     "node_modules/@internal/easter": {
       "resolved": "packages/easter",
       "link": true
@@ -4148,7 +4152,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4723,7 +4726,6 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4981,7 +4983,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4992,7 +4993,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -5040,6 +5040,15 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/conventional-changelog-angular": {
       "version": "9.3.0",
@@ -7079,7 +7088,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14148,7 +14156,6 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15355,6 +15362,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/builder": {
+      "name": "@internal/builder",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "consola": "^3.4.2"
       }
     },
     "packages/easter": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "scripts": {
     "prebuild": "npm run clean",
     "build": "npm run build -w=@internal/easter -w=@internal/lunar-new-year -w=@internal/rite-roman1969",
-    "clean": "rimraf coverage dist tmp && npm run clean -w=@internal/easter -w=@internal/lunar-new-year -w=@internal/rite-roman1969",
+    "clean": "rimraf coverage dist tmp && npm run clean -w=@internal/builder -w=@internal/easter -w=@internal/lunar-new-year -w=@internal/rite-roman1969",
     "data:checks": "npm run data:checks -w=@internal/rite-roman1969",
     "doc": "npm run doc -w=@internal/rite-roman1969",
     "docs:check-links": "npm run docs:check-links -w=@internal/rite-roman1969",

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -1,0 +1,80 @@
+# @internal/builder
+
+Build, bundle, check, document and publish tooling for the romcal rites.
+
+Internal to the romcal monorepo; not published.
+
+## Why
+
+This logic lives in `rites/roman1969/build/` today, and only knows how to build one
+rite: the paths back to the repository root are hardcoded, and the calendar and
+locale globs assume that rite's layout. A second rite would leave two bad options,
+copying the scripts into `rites/roman1962` or having one rite reach into a
+sibling's build directory. Moving it here before `roman1962` exists avoids both.
+
+## Contract
+
+The builder contains no rite name. Everything rite-specific comes from a
+`romcal.build.ts` manifest at the rite root, typed as `RiteBuildManifest`: the
+entry point, output directories, calendar and locale globs, formats to emit, and
+the npm name template for generated bundles. CLI flags override what the manifest
+declares.
+
+That override is the point of the CLI. Rebuilding one calendar in one locale
+during development currently means rebuilding all 104 across 13 locales.
+
+```sh
+tsx packages/builder/src/cli.ts build --rite roman1969 --calendars france --locales fr
+tsx packages/builder/src/cli.ts publish --dry-run
+```
+
+## Logging
+
+`createLogger` is the one place the builder writes to a stream. The scripts being
+moved here each grew their own conventions: two symbol vocabularies, three ways of
+indenting a detail line, and a `hasWarnings` flag in `data-checks.ts` that gets set
+as a side effect of formatting a label. A call site now picks a severity and the
+presentation follows.
+
+[consola](https://github.com/unjs/consola) does the presenting: symbols, colours,
+level filtering, and picking a reporter to suit the output (`◐ building` on a
+terminal, `[start] building` in CI). This module adds the three things a build
+needs that consola has no opinion about: a dry-run tag, nesting, and collapsible
+sections on GitHub Actions.
+
+```ts
+const log = createLogger({ verbose, dryRun });
+
+log.group('bundles', (inner) => {
+  inner.success('france');
+});
+```
+
+Warnings and errors go to stderr, so redirecting stdout to a file keeps problems on
+the terminal. `--dry-run` tags every line, so a rehearsal cannot be mistaken for the
+real thing. Under GitHub Actions, `group` emits the workflow commands that make a
+section collapsible, which matters when 104 bundles each log a line.
+
+None of this reaches a published artifact. The builder runs in Node under `tsx`,
+while the `cjs`, `esm` and `iife` bundles are esbuild's output from a rite's `src`.
+An ESLint rule keeps it that way: `rites/*/src` cannot import `@internal/builder`,
+because that would pull the toolchain into what consumers download.
+
+## Status
+
+Scaffolding only: the types and the argument surface. The commands move over in a
+separate commit, one per source file, so the move can be reviewed as a move.
+
+| Moves from                    | Becomes               |
+| ----------------------------- | --------------------- |
+| `build/build.ts`              | `commands/build.ts`   |
+| `build/bundle.ts`             | `commands/bundle.ts`  |
+| `build/bundle-doc.ts`         | `commands/doc.ts`     |
+| `build/data-checks.ts`        | `commands/check.ts`   |
+| `build/publish.ts`            | `commands/publish.ts` |
+| `build/trusted-publishing.ts` | `commands/trust.ts`   |
+| `build/time.ts`               | `utils/time.ts`       |
+| `build/docs/*.mjs`            | `commands/docs/`      |
+
+The acceptance test for that commit is byte parity: build `dist/` before and after
+and diff the trees.

--- a/packages/builder/jest.config.mjs
+++ b/packages/builder/jest.config.mjs
@@ -1,0 +1,3 @@
+import config from '../../.config/jest.config.mjs';
+
+export default config;

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@internal/builder",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Argument-driven build, bundle, check and publish tooling for the romcal rites.",
+  "license": "MIT",
+  "main": "src/index.ts",
+  "scripts": {
+    "clean": "rimraf coverage",
+    "test": "TZ=UTC jest"
+  },
+  "dependencies": {
+    "chalk": "^4.1.2",
+    "consola": "^3.4.2"
+  }
+}

--- a/packages/builder/src/cli.ts
+++ b/packages/builder/src/cli.ts
@@ -1,0 +1,44 @@
+/**
+ * Command line entry point for the rite build tooling.
+ *
+ * The argument surface is fixed here so that the extraction commit only has to move
+ * code, not decide an interface. Every command reads a `romcal.build.ts` manifest
+ * from the rite root; flags narrow what that manifest declares.
+ */
+
+import { createLogger } from './utils/logger';
+
+const USAGE = `
+romcal-build <command> [options]
+
+Commands:
+  build     Compile a rite and emit its bundles
+  bundle    Emit calendar bundles only
+  check     Run the data checks over a rite's calendars
+  doc       Regenerate the calendar plugin table
+  publish   Publish the rite and its calendar bundles
+  trust     Report or configure trusted publishing
+
+Options:
+  --rite <name>          Rite workspace to act on (default: the only one present)
+  --calendars <list>     Comma separated calendar ids (default: all)
+  --locales <list>       Comma separated locale ids (default: all)
+  --formats <list>       cjs, esm, iife (default: from the manifest)
+  --emit <list>          bundles, docs, packages, types (default: all)
+  --concurrency <n>      Parallel workers (default: one per core)
+  --dry-run              Report what would happen, change nothing
+  --verbose              Log each step
+  --help                 Show this message
+`.trim();
+
+const main = (): void => {
+  const argv = process.argv.slice(2);
+  const log = createLogger({ verbose: argv.includes('--verbose'), dryRun: argv.includes('--dry-run') });
+
+  log.info(USAGE);
+  log.blank();
+  log.error('Not implemented yet: the commands move here from rites/roman1969/build/.');
+  process.exit(1);
+};
+
+main();

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Build, bundle, check, document and publish tooling for the romcal rites.
+ *
+ * Today this logic lives in `rites/roman1969/build/` and only knows how to build
+ * one rite, through hardcoded relative paths. Moving it here, before a second rite
+ * exists, avoids either copying it into `rites/roman1962` or having one rite reach
+ * into a sibling's build directory.
+ *
+ * Only the types and the CLI argument surface are here so far. The commands move
+ * over in a follow-up commit, one per source file; see the README for the mapping.
+ */
+
+export type { BuildArtifact, BuildFormat, ResolvedOptions, RiteBuildManifest } from './types';
+export type { Logger, LoggerOptions, LogLevel } from './utils/logger';
+export { createLogger, logger } from './utils/logger';

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -1,0 +1,54 @@
+/**
+ * The contract between the builder and a rite.
+ *
+ * Everything rite-specific lives in a `romcal.build.ts` manifest at the rite root,
+ * so the builder itself contains no `roman1969` or `roman1962` string. CLI flags
+ * override whatever the manifest declares.
+ */
+
+export type BuildFormat = 'cjs' | 'esm' | 'iife';
+
+export type BuildArtifact = 'bundles' | 'docs' | 'packages' | 'types';
+
+export interface RiteBuildManifest {
+  /** Workspace name, used to resolve the rite root: `@internal/rite-roman1969`. */
+  readonly name: string;
+  /** Entry point of the rite, relative to the rite root. */
+  readonly entryPoint: string;
+  /** Build output directory, relative to the rite root. */
+  readonly outDir: string;
+  /** Scratch directory for intermediate bundles, relative to the rite root. */
+  readonly tmpDir: string;
+  /** Glob matching the calendar definitions, relative to the rite root. */
+  readonly calendars: string;
+  /** Glob matching the locale files, relative to the rite root. */
+  readonly locales: string;
+  /** Formats emitted when `--formats` is not given. */
+  readonly formats: readonly BuildFormat[];
+  /** npm name for a generated calendar bundle; `[calendar]` is substituted. */
+  readonly packageNameTemplate: string;
+  /** Destination of the generated plugin table, relative to the repository root. */
+  readonly docOutput: string;
+}
+
+/**
+ * Resolved options for one command: the manifest with CLI overrides applied.
+ *
+ * `calendars` and `locales` default to everything the manifest globs discover.
+ * Narrowing them is the point of the CLI: a single-calendar rebuild during
+ * development instead of all 104 across 13 locales.
+ */
+export interface ResolvedOptions {
+  readonly manifest: RiteBuildManifest;
+  /** Absolute path to the repository root. */
+  readonly repoRoot: string;
+  /** Absolute path to the rite root. */
+  readonly riteRoot: string;
+  readonly calendars: readonly string[];
+  readonly locales: readonly string[];
+  readonly formats: readonly BuildFormat[];
+  readonly emit: readonly BuildArtifact[];
+  readonly concurrency: number;
+  readonly dryRun: boolean;
+  readonly verbose: boolean;
+}

--- a/packages/builder/src/utils/logger.spec.ts
+++ b/packages/builder/src/utils/logger.spec.ts
@@ -1,0 +1,144 @@
+import { Writable } from 'node:stream';
+
+import { createLogger } from './logger';
+
+/**
+ * Capture a stream's writes. Consola pads warnings and errors with blank lines, so
+ * those are discarded here.
+ *
+ * Which marker precedes a message is consola's business and depends on the
+ * reporter it picks: `◐` on a terminal, `[start]` otherwise, which is what a test
+ * run and CI both see. Assertions below match either, rather than pinning
+ * presentation this module does not own.
+ */
+const capture = (): { lines: () => string[]; stream: NodeJS.WriteStream } => {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback): void {
+      chunks.push(String(chunk));
+      callback();
+    },
+  });
+  return {
+    lines: () =>
+      chunks
+        .join('')
+        .split('\n')
+        .filter((line) => line.trim() !== ''),
+    stream: stream as unknown as NodeJS.WriteStream,
+  };
+};
+
+type Harness = {
+  err: ReturnType<typeof capture>;
+  log: ReturnType<typeof createLogger>;
+  out: ReturnType<typeof capture>;
+};
+
+const setup = (options = {}): Harness => {
+  const out = capture();
+  const err = capture();
+  return { err, log: createLogger({ ...options, stderr: err.stream, stdout: out.stream }), out };
+};
+
+/** The marker consola puts before a message, under either of its reporters. */
+const marked = (type: 'start' | 'success', message: string): RegExp =>
+  new RegExp(`^(?:◐|✔|\\[${type}\\]) ${message}$`);
+
+describe('createLogger', () => {
+  it('gives each severity its own marker', () => {
+    const { log, out } = setup();
+
+    log.step('building');
+    log.success('built');
+    log.info('plain');
+
+    const [step, success, info] = out.lines();
+    expect(step).toMatch(marked('start', 'building'));
+    expect(success).toMatch(marked('success', 'built'));
+    expect(info).toContain('plain');
+  });
+
+  it('writes warnings and errors to stderr, so a redirected stdout still shows them', () => {
+    const { err, log, out } = setup();
+
+    log.info('progress');
+    log.warn('slow');
+    log.error('failed');
+
+    expect(out.lines()).toEqual([expect.stringContaining('progress')]);
+    expect(err.lines()).toEqual([expect.stringContaining('slow'), expect.stringContaining('failed')]);
+  });
+
+  it('drops debug output unless verbose', () => {
+    const quiet = setup();
+    quiet.log.debug('inner detail');
+    expect(quiet.out.lines()).toEqual([]);
+
+    const loud = setup({ verbose: true });
+    loud.log.debug('inner detail');
+    expect(loud.out.lines()).toEqual([expect.stringContaining('inner detail')]);
+  });
+
+  it('tags every line of a dry run, on both streams', () => {
+    const { err, log, out } = setup({ dryRun: true });
+
+    log.step('publishing romcal');
+    log.error('nope');
+
+    expect(out.lines()).toEqual([expect.stringContaining('[dry-run]')]);
+    expect(out.lines()[0]).toContain('publishing romcal');
+    expect(err.lines()).toEqual([expect.stringContaining('[dry-run]')]);
+  });
+
+  it('indents inside a group and returns what the callback returns', () => {
+    const { log, out } = setup();
+
+    const result = log.group('bundles', (inner) => {
+      inner.success('france');
+      return 42;
+    });
+
+    expect(result).toBe(42);
+    const [label, nested] = out.lines();
+    expect(label).toContain('bundles');
+    expect(label).not.toMatch(/^ /);
+    // The indent precedes consola's marker rather than sitting between it and the text.
+    expect(nested).toMatch(/^ {2}(?:✔|\[success\]) france$/);
+  });
+
+  describe('on GitHub Actions', () => {
+    const previous = process.env.GITHUB_ACTIONS;
+    beforeEach(() => {
+      process.env.GITHUB_ACTIONS = 'true';
+    });
+    afterEach(() => {
+      if (previous === undefined) delete process.env.GITHUB_ACTIONS;
+      else process.env.GITHUB_ACTIONS = previous;
+    });
+
+    it('emits workflow commands so long sections collapse', () => {
+      const { log, out } = setup();
+
+      log.group('bundles', (inner) => inner.success('france'));
+
+      const [open, nested, close] = out.lines();
+      expect(open).toBe('::group::bundles');
+      // No indent inside a workflow group: GitHub renders the nesting itself.
+      expect(nested).toMatch(marked('success', 'france'));
+      expect(close).toBe('::endgroup::');
+    });
+
+    it('closes the group even when the callback throws', () => {
+      const { log, out } = setup();
+
+      expect(() =>
+        log.group('bundles', () => {
+          throw new Error('boom');
+        })
+      ).toThrow('boom');
+
+      expect(out.lines()).toEqual(['::group::bundles', '::endgroup::']);
+    });
+  });
+});

--- a/packages/builder/src/utils/logger.ts
+++ b/packages/builder/src/utils/logger.ts
@@ -1,0 +1,140 @@
+import chalk from 'chalk';
+import { ConsolaInstance, createConsola } from 'consola';
+
+/**
+ * The single place the builder writes to a stream.
+ *
+ * The scripts being moved here each grew their own conventions: two symbol
+ * vocabularies, three ways of indenting a detail line, and a `hasWarnings` flag
+ * that data-checks.ts sets as a side effect of formatting a label. A call site now
+ * picks a severity and consola handles the presentation.
+ *
+ * Consola supplies the symbols, colours, level filtering and stream routing, and
+ * drops colour by itself when the output is not a terminal. What it has no opinion
+ * about, and what this wrapper adds, is the three things a build needs: a dry-run
+ * tag, nesting, and collapsible sections on GitHub Actions.
+ *
+ * None of this reaches a published artifact. The builder runs in Node under tsx;
+ * the cjs, esm and iife bundles are esbuild's output from a rite's `src`, which
+ * never imports this package.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/** Consola's numeric levels: warn 1, log 2, info/success 3, debug 4. */
+const CONSOLA_LEVEL: Record<LogLevel, number> = { debug: 4, error: 0, info: 3, warn: 1 };
+
+export interface LoggerOptions {
+  /** Tag every line, so a dry run cannot be mistaken for the real thing. */
+  readonly dryRun?: boolean;
+  /** Lowest level to emit. Anything below is dropped. */
+  readonly level?: LogLevel;
+  readonly stderr?: NodeJS.WriteStream;
+  /** Streams to write to. Injectable so tests can capture output. */
+  readonly stdout?: NodeJS.WriteStream;
+  /** Emit `debug` output. Set by `--verbose`. */
+  readonly verbose?: boolean;
+}
+
+export interface Logger {
+  /** A blank separator line. */
+  blank(): void;
+  /** A logger writing everything indented one level further. */
+  child(): Logger;
+  /** Only with `--verbose`. */
+  debug(message: string): void;
+  /** Secondary output, indented and dimmed under whatever preceded it. */
+  detail(message: string): void;
+  /** Something that failed. Reporting is separate from exiting. */
+  error(message: string): void;
+  /**
+   * Run `fn` inside a collapsible section, passing it a logger that indents one
+   * level further. On GitHub Actions this emits the workflow grouping commands,
+   * which matters when 104 bundles each log a line.
+   */
+  group<T>(label: string, fn: (log: Logger) => T): T;
+  /** Neutral output, no symbol. */
+  info(message: string): void;
+  /** A step that is starting. */
+  step(message: string): void;
+  /** A step that finished. */
+  success(message: string): void;
+  /** Something worth attention that does not stop the build. */
+  warn(message: string): void;
+}
+
+/** GitHub Actions renders `::group::` / `::endgroup::` as a collapsible section. */
+const isGitHubActions = (): boolean => process.env.GITHUB_ACTIONS === 'true';
+
+/**
+ * A view of `target` that indents whatever is written to it.
+ *
+ * Nesting is applied to the rendered line rather than to the message, so the
+ * indent lands before consola's symbol instead of between the symbol and the text.
+ */
+const indented = (target: NodeJS.WriteStream, depth: number): NodeJS.WriteStream => {
+  if (depth === 0) return target;
+  const pad = '  '.repeat(depth);
+
+  return new Proxy(target, {
+    get(stream, property, receiver): unknown {
+      if (property !== 'write') return Reflect.get(stream, property, receiver);
+
+      return (chunk: string | Uint8Array, ...rest: unknown[]): boolean => {
+        const text = String(chunk).replace(/^(?!$)/gm, pad);
+        return (stream.write as (value: string, ...args: unknown[]) => boolean)(text, ...rest);
+      };
+    },
+  });
+};
+
+export const createLogger = (options: LoggerOptions = {}): Logger => {
+  const { dryRun = false, verbose = false } = options;
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  const level = options.level ? CONSOLA_LEVEL[options.level] : CONSOLA_LEVEL[verbose ? 'debug' : 'info'];
+
+  const build = (depth: number): Logger => {
+    const base = createConsola({
+      // A build log is already timestamped by whatever runs it.
+      formatOptions: { date: false },
+      level,
+      stderr: indented(stderr, depth),
+      stdout: indented(stdout, depth),
+    });
+    const consola: ConsolaInstance = dryRun ? base.withTag('dry-run') : base;
+
+    return {
+      blank: () => stdout.write('\n'),
+      child: () => build(depth + 1),
+      debug: (message) => consola.debug(message),
+      detail: (message) => consola.log(chalk.dim(`  ${message}`)),
+      error: (message) => consola.error(message),
+
+      group: <T>(label: string, fn: (log: Logger) => T): T => {
+        if (isGitHubActions()) {
+          // Workflow commands are only recognised at the start of a line.
+          stdout.write(`::group::${label}\n`);
+          try {
+            return fn(build(depth));
+          } finally {
+            stdout.write('::endgroup::\n');
+          }
+        }
+
+        consola.log(chalk.bold(label));
+        return fn(build(depth + 1));
+      },
+
+      info: (message) => consola.log(message),
+      step: (message) => consola.start(message),
+      success: (message) => consola.success(message),
+      warn: (message) => consola.warn(message),
+    };
+  };
+
+  return build(0);
+};
+
+/** Default logger, for call sites with no options to thread through. */
+export const logger = createLogger();

--- a/packages/builder/tsconfig.json
+++ b/packages/builder/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,7 @@
       "@internal/rite-roman1969": ["./rites/roman1969"],
       "@dist/rite-roman1969/*": ["./rites/roman1969/dist/*"],
       "@src/rite-roman1969": ["./rites/roman1969/src"],
+      "@internal/builder": ["./packages/builder"],
       "@internal/easter": ["./packages/easter"],
       "@internal/lunar-new-year": ["./packages/lunar-new-year"],
       "@internal/package.json": ["./package.json"]


### PR DESCRIPTION
## What is the purpose of this pull request?

Scaffolds `@internal/builder`, the package that will own the build, bundle, check,
document and publish tooling for the romcal rites.

That logic lives in `rites/roman1969/build/` today and only knows how to build one
rite: the paths back to the repository root are hardcoded, and the calendar and
locale globs assume that rite's layout. A second rite would leave two bad options,
copying the scripts into `rites/roman1962` or having one rite reach into a
sibling's build directory. Moving it out before `roman1962` exists avoids both.

Nothing moves yet. This PR adds the manifest, tsconfig, jest config, the
`RiteBuildManifest` contract, the CLI argument surface, a logger, and a README
with the file-by-file move table, wired into the root `clean` script, the
`tsconfig.base.json` path alias and both ESLint project arrays. The commands then
move one per commit, with byte parity of `dist/` as the acceptance test.

The builder contains no rite name. Everything rite-specific comes from a
`romcal.build.ts` manifest at the rite root, and CLI flags override what it
declares. That override is the point: rebuilding one calendar in one locale during
development currently means rebuilding all 104 across 13 locales.

The scripts being moved here each grew their own logging conventions: two symbol
vocabularies, three ways of indenting a detail line, and a `hasWarnings` flag in
`data-checks.ts` set as a side effect of formatting a label. A call site now picks
a severity and consola handles the presentation, choosing a reporter to suit the
output. The wrapper adds only what consola has no opinion about: a `--dry-run` tag,
nesting, and collapsible sections on GitHub Actions, which matters when 104 bundles
each log a line. Warnings and errors go to stderr, so redirecting stdout to a file
keeps problems visible. Worth flagging for review: `chalk` is imported by all six
build scripts while declared in no manifest at all, so it has been resolving
transitively. It is now a real dependency of this package.

None of this reaches a published artifact. The builder runs in Node under `tsx`,
while the `cjs`, `esm` and `iife` bundles are esbuild's output from a rite's `src`
— grepping a built `dist/` for `chalk`, `esbuild` or `glob` finds nothing,
including in `dist/iife/romcal.js`. A new ESLint rule keeps it that way:
`rites/*/src` cannot import `@internal/builder`, because that would pull the
toolchain into what consumers download. The rule was verified to fire against a
throwaway file rather than assumed to.

Lint, `tsc --noEmit` and the build are clean, and the full suite passes at 502
tests and 6 snapshots, including 7 new logger tests. `packages/proper-of-time` is
the same groundwork for the shared date logic, in a sibling PR.

## Concept

- Infrastructure

## Example code

No consumer-visible change. Internally, the CLI narrows a build and the commands
share one logger:

```typescript
// tsx packages/builder/src/cli.ts build --rite roman1969 --calendars france --locales fr

const log = createLogger({ verbose, dryRun });

log.group('bundles', (inner) => {
  inner.success('france');
});
```

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](../docs/CODE_OF_CONDUCT.md).
